### PR TITLE
Update CI toolchain pins

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,17 +18,17 @@ jobs:
 
     env:
       XCODEGEN_VERSION: "2.45.3"
-      SWIFTFORMAT_VERSION: "0.61.0"
+      SWIFTFORMAT_VERSION: "0.61.1"
       SWIFTLINT_VERSION: "0.63.2"
 
     steps:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Select Xcode 26.4
+      - name: Select Xcode 26.4.1
         uses: maxim-lobanov/setup-xcode@v1.7.0
         with:
-          xcode-version: '26.4'
+          xcode-version: '26.4.1'
 
       - name: Install tooling
         run: |
@@ -72,10 +72,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Select Xcode 26.4
+      - name: Select Xcode 26.4.1
         uses: maxim-lobanov/setup-xcode@v1.7.0
         with:
-          xcode-version: '26.4'
+          xcode-version: '26.4.1'
 
       - name: Install XcodeGen
         run: |

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Swift project for exploring the traditional Chinese calendar on iOS and macOS.
 ## CI
 
 GitHub Actions runs on pushes to `main`, pull requests, and manual dispatch.
-The workflow runs on `macos-26` with Xcode 26.4, checks formatting, runs linting, and executes `swift test`.
+The workflow runs on `macos-26` with Xcode 26.4.1, checks formatting, runs linting, and executes `swift test`.
 `swiftformat` and `swiftlint` are installed from pinned GitHub Release versions declared in the workflow, so the CI toolchain stays reproducible.
 
 ## Local Tooling


### PR DESCRIPTION
## Summary
- bump CI SwiftFormat pin from `0.61.0` to `0.61.1`
- bump GitHub Actions Xcode pin from `26.4` to `26.4.1` in both jobs
- update the README CI section to match the workflow

## Notes
- left `SWIFTLINT_VERSION` at `0.63.2`
- left `runs-on` at `macos-26`
- no local test run; change is limited to CI config and docs