### PR TITLE
Enable Codex goals feature

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,2 +1,5 @@
 [mcp_servers.sosumi]
 url = "http://127.0.0.1:8787/mcp"
+
+[features]
+goals = true


### PR DESCRIPTION
## Summary
- enable the Codex goals feature flag in local agent config

## Testing
- Not run (configuration-only change)