### PR TITLE
Configure development team for app signing

### DIFF
--- a/project.yml
+++ b/project.yml
@@ -62,6 +62,7 @@ targets:
         SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD: NO
         SWIFT_VERSION: 6.0
         CODE_SIGN_STYLE: Automatic
+        DEVELOPMENT_TEAM: 28TY995J85
         CODE_SIGN_ENTITLEMENTS: Apps/iOSApp/ChineseCalendar-iOS.entitlements
         MARKETING_VERSION: 1.0
         CURRENT_PROJECT_VERSION: 1
@@ -107,6 +108,7 @@ targets:
         INFOPLIST_KEY_LSApplicationCategoryType: public.app-category.reference
         SWIFT_VERSION: 6.0
         CODE_SIGN_STYLE: Automatic
+        DEVELOPMENT_TEAM: 28TY995J85
         CODE_SIGN_ENTITLEMENTS: Apps/macOSApp/ChineseCalendar-macOS.entitlements
         MARKETING_VERSION: 1.0
         CURRENT_PROJECT_VERSION: 1


### PR DESCRIPTION
## Summary
- Add the Apple development team ID to both generated app targets in project.yml.
- Keep App Groups entitlements intact so the shared SwiftData store can still use the app group container.

## Verification
- Ran ./Scripts/generate_xcodeproj.sh.
- Checked generated macOS build settings: DEVELOPMENT_TEAM=28TY995J85 and _DEVELOPMENT_TEAM_IS_EMPTY=NO.
- Started ./Scripts/build_apps.sh; provisioning/signing setup passed with CODE_SIGNING_ALLOWED=NO before the long seed-store generation step was stopped to create this PR.