### PR TITLE
Make calendar navigation state-driven

### DIFF
--- a/Sources/ChineseCalendarUI/CalendarAppState.swift
+++ b/Sources/ChineseCalendarUI/CalendarAppState.swift
@@ -83,7 +83,9 @@ public final class CalendarAppState {
     }
 
     public func selectPreviousYear(in yearNumbers: [Int]) {
-        guard let selectedYearIndex = selectedYearIndex(in: yearNumbers), selectedYearIndex > yearNumbers.startIndex else {
+        guard let selectedYearIndex = selectedYearIndex(in: yearNumbers),
+              selectedYearIndex > yearNumbers.startIndex
+        else {
             return
         }
 
@@ -91,7 +93,9 @@ public final class CalendarAppState {
     }
 
     public func selectNextYear(in yearNumbers: [Int]) {
-        guard let selectedYearIndex = selectedYearIndex(in: yearNumbers), selectedYearIndex < yearNumbers.index(before: yearNumbers.endIndex) else {
+        guard let selectedYearIndex = selectedYearIndex(in: yearNumbers),
+              selectedYearIndex < yearNumbers.index(before: yearNumbers.endIndex)
+        else {
             return
         }
 
@@ -132,7 +136,9 @@ public final class CalendarAppState {
     }
 
     public func selectPreviousMonth(in monthIndexes: [Int]) {
-        guard let selectedMonthIndex = selectedMonthIndex(in: monthIndexes), selectedMonthIndex > monthIndexes.startIndex else {
+        guard let selectedMonthIndex = selectedMonthIndex(in: monthIndexes),
+              selectedMonthIndex > monthIndexes.startIndex
+        else {
             return
         }
 
@@ -140,7 +146,9 @@ public final class CalendarAppState {
     }
 
     public func selectNextMonth(in monthIndexes: [Int]) {
-        guard let selectedMonthIndex = selectedMonthIndex(in: monthIndexes), selectedMonthIndex < monthIndexes.index(before: monthIndexes.endIndex) else {
+        guard let selectedMonthIndex = selectedMonthIndex(in: monthIndexes),
+              selectedMonthIndex < monthIndexes.index(before: monthIndexes.endIndex)
+        else {
             return
         }
 

--- a/Sources/ChineseCalendarUI/CalendarAppState.swift
+++ b/Sources/ChineseCalendarUI/CalendarAppState.swift
@@ -5,44 +5,88 @@ import SwiftUI
 @MainActor
 @Observable
 public final class CalendarAppState {
-    public enum Route: Hashable, Sendable {
-        case lunarYear(Int)
+    public typealias Route = CalendarNavigationState.Route
+
+    public let navigation: CalendarNavigationState
+    public let lunarSelection: LunarSelectionState
+    public let dynastySelection: DynastySelectionState
+
+    public init(
+        navigation: CalendarNavigationState = CalendarNavigationState(),
+        lunarSelection: LunarSelectionState = LunarSelectionState(),
+        dynastySelection: DynastySelectionState = DynastySelectionState()
+    ) {
+        self.navigation = navigation
+        self.lunarSelection = lunarSelection
+        self.dynastySelection = dynastySelection
+        synchronizeSelectionsFromRoute()
     }
 
-    public var columnVisibility: NavigationSplitViewVisibility
+    public convenience init(
+        route: Route? = nil,
+        selectedMonthIndex: Int? = nil,
+        selectedDayIndex: Int? = nil,
+        selectedDynastyID: String? = nil,
+        columnVisibility: NavigationSplitViewVisibility = .automatic
+    ) {
+        self.init(
+            navigation: CalendarNavigationState(route: route, columnVisibility: columnVisibility),
+            lunarSelection: LunarSelectionState(
+                selectedYearNumber: route?.lunarYearNumber,
+                selectedMonthIndex: selectedMonthIndex,
+                selectedDayIndex: selectedDayIndex
+            ),
+            dynastySelection: DynastySelectionState(selectedDynastyID: selectedDynastyID ?? route?.dynastyID)
+        )
+    }
+
+    public var columnVisibility: NavigationSplitViewVisibility {
+        get { navigation.columnVisibility }
+        set { navigation.columnVisibility = newValue }
+    }
+
     public var route: Route? {
-        didSet {
-            guard route != oldValue else {
+        get { navigation.route }
+        set {
+            let oldRoute = navigation.route
+            navigation.route = newValue
+
+            guard newValue != oldRoute else {
                 return
             }
 
-            selectedMonthIndex = nil
+            synchronizeSelectionsFromRoute()
         }
-    }
-
-    public var selectedMonthIndex: Int?
-
-    public init(
-        route: Route? = nil,
-        selectedMonthIndex: Int? = nil,
-        columnVisibility: NavigationSplitViewVisibility = .automatic
-    ) {
-        self.route = route
-        self.selectedMonthIndex = selectedMonthIndex
-        self.columnVisibility = columnVisibility
     }
 
     public var selectedYearNumber: Int? {
-        get {
-            guard case let .lunarYear(yearNumber) = route else {
-                return nil
-            }
+        get { lunarSelection.selectedYearNumber }
+        set { selectLunarYear(number: newValue) }
+    }
 
-            return yearNumber
-        }
-        set {
-            route = newValue.map(Route.lunarYear)
-        }
+    public var selectedMonthIndex: Int? {
+        get { lunarSelection.selectedMonthIndex }
+        set { lunarSelection.selectMonth(index: newValue) }
+    }
+
+    public var selectedDayIndex: Int? {
+        get { lunarSelection.selectedDayIndex }
+        set { lunarSelection.selectDay(index: newValue) }
+    }
+
+    public var selectedDynastyID: String? {
+        get { dynastySelection.selectedDynastyID }
+        set { selectDynasty(id: newValue) }
+    }
+
+    public func selectLunarYear(number: Int?) {
+        lunarSelection.selectYear(number: number)
+        navigation.route = number.map(Route.lunarYear)
+    }
+
+    public func selectDynasty(id: String?) {
+        dynastySelection.selectDynasty(id: id)
+        navigation.route = id.map(Route.dynasty)
     }
 
     @discardableResult
@@ -50,124 +94,88 @@ public final class CalendarAppState {
         from yearNumbers: [Int],
         fallbackYearNumber: Int = ChineseLunarCalendar.yearNumber()
     ) -> Int? {
-        guard !yearNumbers.isEmpty else {
+        guard let selectedYearNumber = lunarSelection.selectDefaultYearIfNeeded(
+            from: yearNumbers,
+            fallbackYearNumber: fallbackYearNumber
+        ) else {
             return nil
         }
 
-        if let selectedYearNumber, yearNumbers.contains(selectedYearNumber) {
-            return nil
+        if navigation.route?.dynastyID == nil {
+            navigation.route = .lunarYear(selectedYearNumber)
         }
 
-        guard let defaultYearNumber = yearNumbers.first(where: { $0 == fallbackYearNumber }) ?? yearNumbers.last else {
-            return nil
-        }
-
-        selectedYearNumber = defaultYearNumber
-        return defaultYearNumber
+        return selectedYearNumber
     }
 
     public func canSelectPreviousYear(in yearNumbers: [Int]) -> Bool {
-        guard let selectedYearIndex = selectedYearIndex(in: yearNumbers) else {
-            return false
-        }
-
-        return selectedYearIndex > yearNumbers.startIndex
+        lunarSelection.canSelectPreviousYear(in: yearNumbers)
     }
 
     public func canSelectNextYear(in yearNumbers: [Int]) -> Bool {
-        guard let selectedYearIndex = selectedYearIndex(in: yearNumbers) else {
-            return false
-        }
-
-        return selectedYearIndex < yearNumbers.index(before: yearNumbers.endIndex)
+        lunarSelection.canSelectNextYear(in: yearNumbers)
     }
 
     public func selectPreviousYear(in yearNumbers: [Int]) {
-        guard let selectedYearIndex = selectedYearIndex(in: yearNumbers),
-              selectedYearIndex > yearNumbers.startIndex
-        else {
-            return
-        }
-
-        selectedYearNumber = yearNumbers[yearNumbers.index(before: selectedYearIndex)]
+        lunarSelection.selectPreviousYear(in: yearNumbers)
+        navigation.route = lunarSelection.selectedYearNumber.map(Route.lunarYear)
     }
 
     public func selectNextYear(in yearNumbers: [Int]) {
-        guard let selectedYearIndex = selectedYearIndex(in: yearNumbers),
-              selectedYearIndex < yearNumbers.index(before: yearNumbers.endIndex)
-        else {
-            return
-        }
-
-        selectedYearNumber = yearNumbers[yearNumbers.index(after: selectedYearIndex)]
+        lunarSelection.selectNextYear(in: yearNumbers)
+        navigation.route = lunarSelection.selectedYearNumber.map(Route.lunarYear)
     }
 
     public func selectMonth(index: Int?) {
-        selectedMonthIndex = index
+        lunarSelection.selectMonth(index: index)
     }
 
     public func selectDefaultMonthIfNeeded(from monthIndexes: [Int]) {
-        guard !monthIndexes.isEmpty else {
-            selectedMonthIndex = nil
-            return
-        }
-
-        guard monthIndexes.contains(where: { $0 == selectedMonthIndex }) == false else {
-            return
-        }
-
-        selectedMonthIndex = monthIndexes.first
+        lunarSelection.selectDefaultMonthIfNeeded(from: monthIndexes)
     }
 
     public func canSelectPreviousMonth(in monthIndexes: [Int]) -> Bool {
-        guard let selectedMonthIndex = selectedMonthIndex(in: monthIndexes) else {
-            return false
-        }
-
-        return selectedMonthIndex > monthIndexes.startIndex
+        lunarSelection.canSelectPreviousMonth(in: monthIndexes)
     }
 
     public func canSelectNextMonth(in monthIndexes: [Int]) -> Bool {
-        guard let selectedMonthIndex = selectedMonthIndex(in: monthIndexes) else {
-            return false
-        }
-
-        return selectedMonthIndex < monthIndexes.index(before: monthIndexes.endIndex)
+        lunarSelection.canSelectNextMonth(in: monthIndexes)
     }
 
     public func selectPreviousMonth(in monthIndexes: [Int]) {
-        guard let selectedMonthIndex = selectedMonthIndex(in: monthIndexes),
-              selectedMonthIndex > monthIndexes.startIndex
-        else {
-            return
-        }
-
-        self.selectedMonthIndex = monthIndexes[monthIndexes.index(before: selectedMonthIndex)]
+        lunarSelection.selectPreviousMonth(in: monthIndexes)
     }
 
     public func selectNextMonth(in monthIndexes: [Int]) {
-        guard let selectedMonthIndex = selectedMonthIndex(in: monthIndexes),
-              selectedMonthIndex < monthIndexes.index(before: monthIndexes.endIndex)
-        else {
-            return
-        }
-
-        self.selectedMonthIndex = monthIndexes[monthIndexes.index(after: selectedMonthIndex)]
+        lunarSelection.selectNextMonth(in: monthIndexes)
     }
 
-    private func selectedYearIndex(in yearNumbers: [Int]) -> [Int].Index? {
-        guard let selectedYearNumber else {
+    private func synchronizeSelectionsFromRoute() {
+        switch navigation.route {
+        case let .lunarYear(yearNumber):
+            lunarSelection.selectYear(number: yearNumber)
+        case let .dynasty(dynastyID):
+            dynastySelection.selectDynasty(id: dynastyID)
+        case nil:
+            lunarSelection.selectYear(number: nil)
+        }
+    }
+}
+
+private extension CalendarNavigationState.Route {
+    var lunarYearNumber: Int? {
+        guard case let .lunarYear(yearNumber) = self else {
             return nil
         }
 
-        return yearNumbers.firstIndex(of: selectedYearNumber)
+        return yearNumber
     }
 
-    private func selectedMonthIndex(in monthIndexes: [Int]) -> [Int].Index? {
-        guard let selectedMonthIndex else {
+    var dynastyID: String? {
+        guard case let .dynasty(dynastyID) = self else {
             return nil
         }
 
-        return monthIndexes.firstIndex(of: selectedMonthIndex)
+        return dynastyID
     }
 }

--- a/Sources/ChineseCalendarUI/CalendarAppState.swift
+++ b/Sources/ChineseCalendarUI/CalendarAppState.swift
@@ -1,0 +1,165 @@
+import ChineseCalendarCore
+import Observation
+import SwiftUI
+
+@MainActor
+@Observable
+public final class CalendarAppState {
+    public enum Route: Hashable, Sendable {
+        case lunarYear(Int)
+    }
+
+    public var columnVisibility: NavigationSplitViewVisibility
+    public var route: Route? {
+        didSet {
+            guard route != oldValue else {
+                return
+            }
+
+            selectedMonthIndex = nil
+        }
+    }
+
+    public var selectedMonthIndex: Int?
+
+    public init(
+        route: Route? = nil,
+        selectedMonthIndex: Int? = nil,
+        columnVisibility: NavigationSplitViewVisibility = .automatic
+    ) {
+        self.route = route
+        self.selectedMonthIndex = selectedMonthIndex
+        self.columnVisibility = columnVisibility
+    }
+
+    public var selectedYearNumber: Int? {
+        get {
+            guard case let .lunarYear(yearNumber) = route else {
+                return nil
+            }
+
+            return yearNumber
+        }
+        set {
+            route = newValue.map(Route.lunarYear)
+        }
+    }
+
+    @discardableResult
+    public func selectDefaultYearIfNeeded(
+        from yearNumbers: [Int],
+        fallbackYearNumber: Int = ChineseLunarCalendar.yearNumber()
+    ) -> Int? {
+        guard !yearNumbers.isEmpty else {
+            return nil
+        }
+
+        if let selectedYearNumber, yearNumbers.contains(selectedYearNumber) {
+            return nil
+        }
+
+        guard let defaultYearNumber = yearNumbers.first(where: { $0 == fallbackYearNumber }) ?? yearNumbers.last else {
+            return nil
+        }
+
+        selectedYearNumber = defaultYearNumber
+        return defaultYearNumber
+    }
+
+    public func canSelectPreviousYear(in yearNumbers: [Int]) -> Bool {
+        guard let selectedYearIndex = selectedYearIndex(in: yearNumbers) else {
+            return false
+        }
+
+        return selectedYearIndex > yearNumbers.startIndex
+    }
+
+    public func canSelectNextYear(in yearNumbers: [Int]) -> Bool {
+        guard let selectedYearIndex = selectedYearIndex(in: yearNumbers) else {
+            return false
+        }
+
+        return selectedYearIndex < yearNumbers.index(before: yearNumbers.endIndex)
+    }
+
+    public func selectPreviousYear(in yearNumbers: [Int]) {
+        guard let selectedYearIndex = selectedYearIndex(in: yearNumbers), selectedYearIndex > yearNumbers.startIndex else {
+            return
+        }
+
+        selectedYearNumber = yearNumbers[yearNumbers.index(before: selectedYearIndex)]
+    }
+
+    public func selectNextYear(in yearNumbers: [Int]) {
+        guard let selectedYearIndex = selectedYearIndex(in: yearNumbers), selectedYearIndex < yearNumbers.index(before: yearNumbers.endIndex) else {
+            return
+        }
+
+        selectedYearNumber = yearNumbers[yearNumbers.index(after: selectedYearIndex)]
+    }
+
+    public func selectMonth(index: Int?) {
+        selectedMonthIndex = index
+    }
+
+    public func selectDefaultMonthIfNeeded(from monthIndexes: [Int]) {
+        guard !monthIndexes.isEmpty else {
+            selectedMonthIndex = nil
+            return
+        }
+
+        guard monthIndexes.contains(where: { $0 == selectedMonthIndex }) == false else {
+            return
+        }
+
+        selectedMonthIndex = monthIndexes.first
+    }
+
+    public func canSelectPreviousMonth(in monthIndexes: [Int]) -> Bool {
+        guard let selectedMonthIndex = selectedMonthIndex(in: monthIndexes) else {
+            return false
+        }
+
+        return selectedMonthIndex > monthIndexes.startIndex
+    }
+
+    public func canSelectNextMonth(in monthIndexes: [Int]) -> Bool {
+        guard let selectedMonthIndex = selectedMonthIndex(in: monthIndexes) else {
+            return false
+        }
+
+        return selectedMonthIndex < monthIndexes.index(before: monthIndexes.endIndex)
+    }
+
+    public func selectPreviousMonth(in monthIndexes: [Int]) {
+        guard let selectedMonthIndex = selectedMonthIndex(in: monthIndexes), selectedMonthIndex > monthIndexes.startIndex else {
+            return
+        }
+
+        self.selectedMonthIndex = monthIndexes[monthIndexes.index(before: selectedMonthIndex)]
+    }
+
+    public func selectNextMonth(in monthIndexes: [Int]) {
+        guard let selectedMonthIndex = selectedMonthIndex(in: monthIndexes), selectedMonthIndex < monthIndexes.index(before: monthIndexes.endIndex) else {
+            return
+        }
+
+        self.selectedMonthIndex = monthIndexes[monthIndexes.index(after: selectedMonthIndex)]
+    }
+
+    private func selectedYearIndex(in yearNumbers: [Int]) -> [Int].Index? {
+        guard let selectedYearNumber else {
+            return nil
+        }
+
+        return yearNumbers.firstIndex(of: selectedYearNumber)
+    }
+
+    private func selectedMonthIndex(in monthIndexes: [Int]) -> [Int].Index? {
+        guard let selectedMonthIndex else {
+            return nil
+        }
+
+        return monthIndexes.firstIndex(of: selectedMonthIndex)
+    }
+}

--- a/Sources/ChineseCalendarUI/CalendarHomeView.swift
+++ b/Sources/ChineseCalendarUI/CalendarHomeView.swift
@@ -20,10 +20,10 @@ public struct CalendarHomeView: View {
     }
 
     public var body: some View {
-        @Bindable var appState = appState
+        @Bindable var state = appState
 
-        NavigationSplitView(columnVisibility: $appState.columnVisibility) {
-            List(selection: $appState.route) {
+        NavigationSplitView(columnVisibility: $state.columnVisibility) {
+            List(selection: $state.route) {
                 Section("农历年") {
                     ForEach(years, id: \.lunarYearNumber) { year in
                         LunarYearRow(year: year)
@@ -37,7 +37,7 @@ public struct CalendarHomeView: View {
                 if let selectedYear {
                     LunarYearDetailView(
                         year: selectedYear,
-                        state: appState,
+                        state: state,
                         yearNumbers: yearNumbers
                     )
                 } else {
@@ -62,7 +62,7 @@ public struct CalendarHomeView: View {
     }
 
     private var selectedYear: ChineseLunarYear? {
-        guard let selectedYearNumber = appState.selectedYearNumber else {
+        guard case let .lunarYear(selectedYearNumber) = appState.route else {
             return nil
         }
 

--- a/Sources/ChineseCalendarUI/CalendarHomeView.swift
+++ b/Sources/ChineseCalendarUI/CalendarHomeView.swift
@@ -6,21 +6,28 @@ import SwiftUI
 
 public struct CalendarHomeView: View {
     @Query(sort: \ChineseLunarYear.lunarYearNumber) private var years: [ChineseLunarYear]
-    @State private var selectedYearNumber: Int?
-    @State private var selectedMonthIndex: Int?
+    @State private var appState: CalendarAppState
 
-    public init() {}
+    @MainActor
+    public init(appState: CalendarAppState = CalendarAppState()) {
+        _appState = State(initialValue: appState)
+    }
 
     @available(*, deprecated, message: "CalendarHomeView now selects the current lunar year automatically.")
-    public init(selectedDate _: ChineseCalendarDate?) {}
+    @MainActor
+    public init(selectedDate _: ChineseCalendarDate?) {
+        _appState = State(initialValue: CalendarAppState())
+    }
 
     public var body: some View {
-        NavigationSplitView {
-            List(selection: $selectedYearNumber) {
+        @Bindable var appState = appState
+
+        NavigationSplitView(columnVisibility: $appState.columnVisibility) {
+            List(selection: $appState.route) {
                 Section("农历年") {
                     ForEach(years, id: \.lunarYearNumber) { year in
                         LunarYearRow(year: year)
-                            .tag(year.lunarYearNumber)
+                            .tag(CalendarAppState.Route.lunarYear(year.lunarYearNumber))
                     }
                 }
             }
@@ -30,11 +37,8 @@ public struct CalendarHomeView: View {
                 if let selectedYear {
                     LunarYearDetailView(
                         year: selectedYear,
-                        selectedMonthIndex: $selectedMonthIndex,
-                        canSelectPreviousYear: canSelectPreviousYear,
-                        canSelectNextYear: canSelectNextYear,
-                        selectPreviousYear: selectPreviousYear,
-                        selectNextYear: selectNextYear
+                        state: appState,
+                        yearNumbers: yearNumbers
                     )
                 } else {
                     ContentUnavailableView {
@@ -51,41 +55,18 @@ public struct CalendarHomeView: View {
         .onChange(of: years.map(\.lunarYearNumber)) {
             selectDefaultYearIfNeeded()
         }
-        .onChange(of: selectedYearNumber) {
-            selectedMonthIndex = nil
-        }
+    }
+
+    private var yearNumbers: [Int] {
+        years.map(\.lunarYearNumber)
     }
 
     private var selectedYear: ChineseLunarYear? {
-        guard let selectedYearNumber else {
+        guard let selectedYearNumber = appState.selectedYearNumber else {
             return nil
         }
 
         return years.first { $0.lunarYearNumber == selectedYearNumber }
-    }
-
-    private var selectedYearIndex: Int? {
-        guard let selectedYearNumber else {
-            return nil
-        }
-
-        return years.firstIndex { $0.lunarYearNumber == selectedYearNumber }
-    }
-
-    private var canSelectPreviousYear: Bool {
-        guard let selectedYearIndex else {
-            return false
-        }
-
-        return selectedYearIndex > years.startIndex
-    }
-
-    private var canSelectNextYear: Bool {
-        guard let selectedYearIndex else {
-            return false
-        }
-
-        return selectedYearIndex < years.index(before: years.endIndex)
     }
 
     private var emptyStateDescription: String {
@@ -102,33 +83,11 @@ public struct CalendarHomeView: View {
             return
         }
 
-        guard selectedYear == nil else {
+        guard let defaultYearNumber = appState.selectDefaultYearIfNeeded(from: yearNumbers) else {
             return
         }
 
-        let fallbackYearNumber = ChineseLunarCalendar.yearNumber()
-        selectedYearNumber = years.first { $0.lunarYearNumber == fallbackYearNumber }?.lunarYearNumber
-            ?? years.last?.lunarYearNumber
-
-        if let selectedYearNumber {
-            ChineseCalendarLog.ui.info("Selected default lunar year \(selectedYearNumber)")
-        }
-    }
-
-    private func selectPreviousYear() {
-        guard let selectedYearIndex, selectedYearIndex > years.startIndex else {
-            return
-        }
-
-        selectedYearNumber = years[years.index(before: selectedYearIndex)].lunarYearNumber
-    }
-
-    private func selectNextYear() {
-        guard let selectedYearIndex, selectedYearIndex < years.index(before: years.endIndex) else {
-            return
-        }
-
-        selectedYearNumber = years[years.index(after: selectedYearIndex)].lunarYearNumber
+        ChineseCalendarLog.ui.info("Selected default lunar year \(defaultYearNumber)")
     }
 }
 

--- a/Sources/ChineseCalendarUI/CalendarNavigationState.swift
+++ b/Sources/ChineseCalendarUI/CalendarNavigationState.swift
@@ -1,0 +1,22 @@
+import Observation
+import SwiftUI
+
+@MainActor
+@Observable
+public final class CalendarNavigationState {
+    public enum Route: Hashable, Sendable {
+        case lunarYear(Int)
+        case dynasty(String)
+    }
+
+    public var columnVisibility: NavigationSplitViewVisibility
+    public var route: Route?
+
+    public init(
+        route: Route? = nil,
+        columnVisibility: NavigationSplitViewVisibility = .automatic
+    ) {
+        self.route = route
+        self.columnVisibility = columnVisibility
+    }
+}

--- a/Sources/ChineseCalendarUI/DynastySelectionState.swift
+++ b/Sources/ChineseCalendarUI/DynastySelectionState.swift
@@ -1,0 +1,37 @@
+import Observation
+
+@MainActor
+@Observable
+public final class DynastySelectionState {
+    public var selectedDynastyID: String?
+    public var selectedOrthodoxTraditionID: String?
+    public var selectedOrthodoxPeriodID: String?
+
+    public init(
+        selectedDynastyID: String? = nil,
+        selectedOrthodoxTraditionID: String? = nil,
+        selectedOrthodoxPeriodID: String? = nil
+    ) {
+        self.selectedDynastyID = selectedDynastyID
+        self.selectedOrthodoxTraditionID = selectedOrthodoxTraditionID
+        self.selectedOrthodoxPeriodID = selectedOrthodoxPeriodID
+    }
+
+    public func selectDynasty(id: String?) {
+        selectedDynastyID = id
+    }
+
+    public func selectOrthodoxTradition(id: String?) {
+        selectedOrthodoxTraditionID = id
+    }
+
+    public func selectOrthodoxPeriod(id: String?) {
+        selectedOrthodoxPeriodID = id
+    }
+
+    public func clearSelection() {
+        selectedDynastyID = nil
+        selectedOrthodoxTraditionID = nil
+        selectedOrthodoxPeriodID = nil
+    }
+}

--- a/Sources/ChineseCalendarUI/LunarSelectionState.swift
+++ b/Sources/ChineseCalendarUI/LunarSelectionState.swift
@@ -1,0 +1,190 @@
+import ChineseCalendarCore
+import Observation
+
+@MainActor
+@Observable
+public final class LunarSelectionState {
+    public var selectedYearNumber: Int? {
+        didSet {
+            guard selectedYearNumber != oldValue else {
+                return
+            }
+
+            clearMonthAndDaySelection()
+        }
+    }
+
+    public var selectedMonthIndex: Int? {
+        didSet {
+            guard selectedMonthIndex != oldValue else {
+                return
+            }
+
+            selectedDayIndex = nil
+        }
+    }
+
+    public var selectedDayIndex: Int?
+
+    public init(
+        selectedYearNumber: Int? = nil,
+        selectedMonthIndex: Int? = nil,
+        selectedDayIndex: Int? = nil
+    ) {
+        self.selectedYearNumber = selectedYearNumber
+        self.selectedMonthIndex = selectedMonthIndex
+        self.selectedDayIndex = selectedDayIndex
+    }
+
+    public func selectYear(number: Int?) {
+        selectedYearNumber = number
+    }
+
+    @discardableResult
+    public func selectDefaultYearIfNeeded(
+        from yearNumbers: [Int],
+        fallbackYearNumber: Int = ChineseLunarCalendar.yearNumber()
+    ) -> Int? {
+        guard !yearNumbers.isEmpty else {
+            return nil
+        }
+
+        if let selectedYearNumber, yearNumbers.contains(selectedYearNumber) {
+            return nil
+        }
+
+        guard let defaultYearNumber = yearNumbers.first(where: { $0 == fallbackYearNumber }) ?? yearNumbers.last else {
+            return nil
+        }
+
+        selectedYearNumber = defaultYearNumber
+        return defaultYearNumber
+    }
+
+    public func canSelectPreviousYear(in yearNumbers: [Int]) -> Bool {
+        guard let selectedYearIndex = selectedYearIndex(in: yearNumbers) else {
+            return false
+        }
+
+        return selectedYearIndex > yearNumbers.startIndex
+    }
+
+    public func canSelectNextYear(in yearNumbers: [Int]) -> Bool {
+        guard let selectedYearIndex = selectedYearIndex(in: yearNumbers) else {
+            return false
+        }
+
+        return selectedYearIndex < yearNumbers.index(before: yearNumbers.endIndex)
+    }
+
+    public func selectPreviousYear(in yearNumbers: [Int]) {
+        guard let selectedYearIndex = selectedYearIndex(in: yearNumbers),
+              selectedYearIndex > yearNumbers.startIndex
+        else {
+            return
+        }
+
+        selectedYearNumber = yearNumbers[yearNumbers.index(before: selectedYearIndex)]
+    }
+
+    public func selectNextYear(in yearNumbers: [Int]) {
+        guard let selectedYearIndex = selectedYearIndex(in: yearNumbers),
+              selectedYearIndex < yearNumbers.index(before: yearNumbers.endIndex)
+        else {
+            return
+        }
+
+        selectedYearNumber = yearNumbers[yearNumbers.index(after: selectedYearIndex)]
+    }
+
+    public func selectMonth(index: Int?) {
+        selectedMonthIndex = index
+    }
+
+    public func selectDefaultMonthIfNeeded(from monthIndexes: [Int]) {
+        guard !monthIndexes.isEmpty else {
+            selectedMonthIndex = nil
+            return
+        }
+
+        guard monthIndexes.contains(where: { $0 == selectedMonthIndex }) == false else {
+            return
+        }
+
+        selectedMonthIndex = monthIndexes.first
+    }
+
+    public func canSelectPreviousMonth(in monthIndexes: [Int]) -> Bool {
+        guard let selectedMonthIndex = selectedMonthIndex(in: monthIndexes) else {
+            return false
+        }
+
+        return selectedMonthIndex > monthIndexes.startIndex
+    }
+
+    public func canSelectNextMonth(in monthIndexes: [Int]) -> Bool {
+        guard let selectedMonthIndex = selectedMonthIndex(in: monthIndexes) else {
+            return false
+        }
+
+        return selectedMonthIndex < monthIndexes.index(before: monthIndexes.endIndex)
+    }
+
+    public func selectPreviousMonth(in monthIndexes: [Int]) {
+        guard let selectedMonthIndex = selectedMonthIndex(in: monthIndexes),
+              selectedMonthIndex > monthIndexes.startIndex
+        else {
+            return
+        }
+
+        self.selectedMonthIndex = monthIndexes[monthIndexes.index(before: selectedMonthIndex)]
+    }
+
+    public func selectNextMonth(in monthIndexes: [Int]) {
+        guard let selectedMonthIndex = selectedMonthIndex(in: monthIndexes),
+              selectedMonthIndex < monthIndexes.index(before: monthIndexes.endIndex)
+        else {
+            return
+        }
+
+        self.selectedMonthIndex = monthIndexes[monthIndexes.index(after: selectedMonthIndex)]
+    }
+
+    public func selectDay(index: Int?) {
+        selectedDayIndex = index
+    }
+
+    public func selectDefaultDayIfNeeded(from dayIndexes: [Int]) {
+        guard !dayIndexes.isEmpty else {
+            selectedDayIndex = nil
+            return
+        }
+
+        guard dayIndexes.contains(where: { $0 == selectedDayIndex }) == false else {
+            return
+        }
+
+        selectedDayIndex = dayIndexes.first
+    }
+
+    public func clearMonthAndDaySelection() {
+        selectedMonthIndex = nil
+        selectedDayIndex = nil
+    }
+
+    private func selectedYearIndex(in yearNumbers: [Int]) -> [Int].Index? {
+        guard let selectedYearNumber else {
+            return nil
+        }
+
+        return yearNumbers.firstIndex(of: selectedYearNumber)
+    }
+
+    private func selectedMonthIndex(in monthIndexes: [Int]) -> [Int].Index? {
+        guard let selectedMonthIndex else {
+            return nil
+        }
+
+        return monthIndexes.firstIndex(of: selectedMonthIndex)
+    }
+}

--- a/Sources/ChineseCalendarUI/LunarYearDetailView.swift
+++ b/Sources/ChineseCalendarUI/LunarYearDetailView.swift
@@ -5,28 +5,19 @@ import SwiftUI
 
 struct LunarYearDetailView: View {
     let year: ChineseLunarYear
-    @Binding var selectedMonthIndex: Int?
-    let canSelectPreviousYear: Bool
-    let canSelectNextYear: Bool
-    let selectPreviousYear: () -> Void
-    let selectNextYear: () -> Void
+    @Bindable var state: CalendarAppState
+    let yearNumbers: [Int]
 
     @Query private var months: [ChineseLunarMonth]
 
     init(
         year: ChineseLunarYear,
-        selectedMonthIndex: Binding<Int?>,
-        canSelectPreviousYear: Bool,
-        canSelectNextYear: Bool,
-        selectPreviousYear: @escaping () -> Void,
-        selectNextYear: @escaping () -> Void
+        state: CalendarAppState,
+        yearNumbers: [Int]
     ) {
         self.year = year
-        _selectedMonthIndex = selectedMonthIndex
-        self.canSelectPreviousYear = canSelectPreviousYear
-        self.canSelectNextYear = canSelectNextYear
-        self.selectPreviousYear = selectPreviousYear
-        self.selectNextYear = selectNextYear
+        self.state = state
+        self.yearNumbers = yearNumbers
 
         let lunarYearNumber = year.lunarYearNumber
         _months = Query(
@@ -38,7 +29,7 @@ struct LunarYearDetailView: View {
     }
 
     private var selectedMonth: ChineseLunarMonth? {
-        guard let selectedMonthIndex else {
+        guard let selectedMonthIndex = state.selectedMonthIndex else {
             return monthsInYearStartOrder.first
         }
 
@@ -63,7 +54,7 @@ struct LunarYearDetailView: View {
                     MonthSwitcher(
                         months: monthsInYearStartOrder,
                         selectedMonth: selectedMonth,
-                        selectedMonthIndex: $selectedMonthIndex
+                        state: state
                     )
 
                     LunarMonthGrid(month: selectedMonth)
@@ -79,12 +70,16 @@ struct LunarYearDetailView: View {
         .navigationTitle(LunarCalendarFormatting.yearTitle(lunarYearNumber: year.lunarYearNumber))
         .toolbar {
             ToolbarItemGroup(placement: .primaryAction) {
-                Button("上一年", systemImage: "chevron.left", action: selectPreviousYear)
-                    .disabled(!canSelectPreviousYear)
+                Button("上一年", systemImage: "chevron.left") {
+                    state.selectPreviousYear(in: yearNumbers)
+                }
+                .disabled(!state.canSelectPreviousYear(in: yearNumbers))
                     .help("切换到上一年")
 
-                Button("下一年", systemImage: "chevron.right", action: selectNextYear)
-                    .disabled(!canSelectNextYear)
+                Button("下一年", systemImage: "chevron.right") {
+                    state.selectNextYear(in: yearNumbers)
+                }
+                .disabled(!state.canSelectNextYear(in: yearNumbers))
                     .help("切换到下一年")
             }
         }
@@ -99,10 +94,6 @@ struct LunarYearDetailView: View {
     }
 
     private func selectDefaultMonthIfNeeded() {
-        guard monthsInYearStartOrder.contains(where: { $0.lunarMonthIndex == selectedMonthIndex }) == false else {
-            return
-        }
-
-        selectedMonthIndex = monthsInYearStartOrder.first?.lunarMonthIndex
+        state.selectDefaultMonthIfNeeded(from: monthsInYearStartOrder.map(\.lunarMonthIndex))
     }
 }

--- a/Sources/ChineseCalendarUI/LunarYearDetailView.swift
+++ b/Sources/ChineseCalendarUI/LunarYearDetailView.swift
@@ -74,13 +74,13 @@ struct LunarYearDetailView: View {
                     state.selectPreviousYear(in: yearNumbers)
                 }
                 .disabled(!state.canSelectPreviousYear(in: yearNumbers))
-                    .help("切换到上一年")
+                .help("切换到上一年")
 
                 Button("下一年", systemImage: "chevron.right") {
                     state.selectNextYear(in: yearNumbers)
                 }
                 .disabled(!state.canSelectNextYear(in: yearNumbers))
-                    .help("切换到下一年")
+                .help("切换到下一年")
             }
         }
     }

--- a/Sources/ChineseCalendarUI/MonthSwitcher.swift
+++ b/Sources/ChineseCalendarUI/MonthSwitcher.swift
@@ -5,26 +5,18 @@ import SwiftUI
 struct MonthSwitcher: View {
     let months: [ChineseLunarMonth]
     let selectedMonth: ChineseLunarMonth
-    @Binding var selectedMonthIndex: Int?
+    @Bindable var state: CalendarAppState
 
-    private var selectedIndex: Int? {
-        months.firstIndex { $0.lunarMonthIndex == selectedMonth.lunarMonthIndex }
+    private var monthIndexes: [Int] {
+        months.map(\.lunarMonthIndex)
     }
 
     private var canSelectPreviousMonth: Bool {
-        guard let selectedIndex else {
-            return false
-        }
-
-        return selectedIndex > months.startIndex
+        state.canSelectPreviousMonth(in: monthIndexes)
     }
 
     private var canSelectNextMonth: Bool {
-        guard let selectedIndex else {
-            return false
-        }
-
-        return selectedIndex < months.index(before: months.endIndex)
+        state.canSelectNextMonth(in: monthIndexes)
     }
 
     var body: some View {
@@ -59,7 +51,7 @@ struct MonthSwitcher: View {
                 HStack(spacing: 8) {
                     ForEach(months, id: \.lunarMonthIndex) { month in
                         Button {
-                            selectedMonthIndex = month.lunarMonthIndex
+                            state.selectMonth(index: month.lunarMonthIndex)
                         } label: {
                             VStack(spacing: 4) {
                                 Text(monthTitle(month))
@@ -82,19 +74,11 @@ struct MonthSwitcher: View {
     }
 
     private func selectPreviousMonth() {
-        guard let selectedIndex, selectedIndex > months.startIndex else {
-            return
-        }
-
-        selectedMonthIndex = months[months.index(before: selectedIndex)].lunarMonthIndex
+        state.selectPreviousMonth(in: monthIndexes)
     }
 
     private func selectNextMonth() {
-        guard let selectedIndex, selectedIndex < months.index(before: months.endIndex) else {
-            return
-        }
-
-        selectedMonthIndex = months[months.index(after: selectedIndex)].lunarMonthIndex
+        state.selectNextMonth(in: monthIndexes)
     }
 
     private func monthTitle(_ month: ChineseLunarMonth) -> String {

--- a/Sources/ChineseCalendarUI/Tests/CalendarAppStateTests.swift
+++ b/Sources/ChineseCalendarUI/Tests/CalendarAppStateTests.swift
@@ -4,8 +4,45 @@ import Testing
 @MainActor
 @Suite("Calendar app state")
 struct CalendarAppStateTests {
-    @Test("selects fallback year when available")
-    func selectsFallbackYearWhenAvailable() {
+    @Test("route selection updates lunar child state")
+    func routeSelectionUpdatesLunarChildState() {
+        let state = CalendarAppState(
+            route: .lunarYear(2024),
+            selectedMonthIndex: 12,
+            selectedDayIndex: 345
+        )
+
+        state.route = .lunarYear(2025)
+
+        #expect(state.selectedYearNumber == 2025)
+        #expect(state.lunarSelection.selectedYearNumber == 2025)
+        #expect(state.selectedMonthIndex == nil)
+        #expect(state.selectedDayIndex == nil)
+    }
+
+    @Test("lunar selection updates route")
+    func lunarSelectionUpdatesRoute() {
+        let state = CalendarAppState()
+
+        state.selectLunarYear(number: 2025)
+
+        #expect(state.route == .lunarYear(2025))
+        #expect(state.lunarSelection.selectedYearNumber == 2025)
+    }
+
+    @Test("dynasty selection updates dynasty child state and route")
+    func dynastySelectionUpdatesDynastyChildStateAndRoute() {
+        let state = CalendarAppState()
+
+        state.selectDynasty(id: "ming")
+
+        #expect(state.route == .dynasty("ming"))
+        #expect(state.selectedDynastyID == "ming")
+        #expect(state.dynastySelection.selectedDynastyID == "ming")
+    }
+
+    @Test("default year selection keeps app route synchronized")
+    func defaultYearSelectionKeepsAppRouteSynchronized() {
         let state = CalendarAppState()
 
         let selectedYearNumber = state.selectDefaultYearIfNeeded(
@@ -14,86 +51,21 @@ struct CalendarAppStateTests {
         )
 
         #expect(selectedYearNumber == 2025)
-        #expect(state.selectedYearNumber == 2025)
         #expect(state.route == .lunarYear(2025))
+        #expect(state.lunarSelection.selectedYearNumber == 2025)
     }
 
-    @Test("selects last year when fallback is unavailable")
-    func selectsLastYearWhenFallbackIsUnavailable() {
-        let state = CalendarAppState()
-
-        let selectedYearNumber = state.selectDefaultYearIfNeeded(
-            from: [2024, 2025, 2026],
-            fallbackYearNumber: 2030
-        )
-
-        #expect(selectedYearNumber == 2026)
-        #expect(state.selectedYearNumber == 2026)
-    }
-
-    @Test("keeps existing valid year")
-    func keepsExistingValidYear() {
-        let state = CalendarAppState(route: .lunarYear(2024))
+    @Test("default year selection preserves dynasty route")
+    func defaultYearSelectionPreservesDynastyRoute() {
+        let state = CalendarAppState(route: .dynasty("ming"))
 
         let selectedYearNumber = state.selectDefaultYearIfNeeded(
             from: [2024, 2025, 2026],
             fallbackYearNumber: 2025
         )
 
-        #expect(selectedYearNumber == nil)
-        #expect(state.selectedYearNumber == 2024)
-    }
-
-    @Test("clears selected month when route changes")
-    func clearsSelectedMonthWhenRouteChanges() {
-        let state = CalendarAppState(route: .lunarYear(2024), selectedMonthIndex: 12)
-
-        state.route = .lunarYear(2025)
-
-        #expect(state.selectedYearNumber == 2025)
-        #expect(state.selectedMonthIndex == nil)
-    }
-
-    @Test("keeps selected month when route is unchanged")
-    func keepsSelectedMonthWhenRouteIsUnchanged() {
-        let state = CalendarAppState(route: .lunarYear(2024), selectedMonthIndex: 12)
-
-        state.route = .lunarYear(2024)
-
-        #expect(state.selectedMonthIndex == 12)
-    }
-
-    @Test("selects adjacent years within bounds")
-    func selectsAdjacentYearsWithinBounds() {
-        let state = CalendarAppState(route: .lunarYear(2025))
-        let yearNumbers = [2024, 2025, 2026]
-
-        #expect(state.canSelectPreviousYear(in: yearNumbers))
-        #expect(state.canSelectNextYear(in: yearNumbers))
-
-        state.selectPreviousYear(in: yearNumbers)
-        #expect(state.selectedYearNumber == 2024)
-        #expect(!state.canSelectPreviousYear(in: yearNumbers))
-
-        state.selectNextYear(in: yearNumbers)
-        state.selectNextYear(in: yearNumbers)
-        #expect(state.selectedYearNumber == 2026)
-        #expect(!state.canSelectNextYear(in: yearNumbers))
-    }
-
-    @Test("selects default month and adjacent months")
-    func selectsDefaultMonthAndAdjacentMonths() {
-        let state = CalendarAppState()
-        let monthIndexes = [101, 102, 103]
-
-        state.selectDefaultMonthIfNeeded(from: monthIndexes)
-        #expect(state.selectedMonthIndex == 101)
-
-        state.selectNextMonth(in: monthIndexes)
-        #expect(state.selectedMonthIndex == 102)
-
-        state.selectPreviousMonth(in: monthIndexes)
-        #expect(state.selectedMonthIndex == 101)
-        #expect(!state.canSelectPreviousMonth(in: monthIndexes))
+        #expect(selectedYearNumber == 2025)
+        #expect(state.route == .dynasty("ming"))
+        #expect(state.lunarSelection.selectedYearNumber == 2025)
     }
 }

--- a/Sources/ChineseCalendarUI/Tests/CalendarAppStateTests.swift
+++ b/Sources/ChineseCalendarUI/Tests/CalendarAppStateTests.swift
@@ -1,5 +1,5 @@
-import Testing
 @testable import ChineseCalendarUI
+import Testing
 
 @MainActor
 @Suite("Calendar app state")

--- a/Sources/ChineseCalendarUI/Tests/CalendarAppStateTests.swift
+++ b/Sources/ChineseCalendarUI/Tests/CalendarAppStateTests.swift
@@ -1,0 +1,99 @@
+import Testing
+@testable import ChineseCalendarUI
+
+@MainActor
+@Suite("Calendar app state")
+struct CalendarAppStateTests {
+    @Test("selects fallback year when available")
+    func selectsFallbackYearWhenAvailable() {
+        let state = CalendarAppState()
+
+        let selectedYearNumber = state.selectDefaultYearIfNeeded(
+            from: [2024, 2025, 2026],
+            fallbackYearNumber: 2025
+        )
+
+        #expect(selectedYearNumber == 2025)
+        #expect(state.selectedYearNumber == 2025)
+        #expect(state.route == .lunarYear(2025))
+    }
+
+    @Test("selects last year when fallback is unavailable")
+    func selectsLastYearWhenFallbackIsUnavailable() {
+        let state = CalendarAppState()
+
+        let selectedYearNumber = state.selectDefaultYearIfNeeded(
+            from: [2024, 2025, 2026],
+            fallbackYearNumber: 2030
+        )
+
+        #expect(selectedYearNumber == 2026)
+        #expect(state.selectedYearNumber == 2026)
+    }
+
+    @Test("keeps existing valid year")
+    func keepsExistingValidYear() {
+        let state = CalendarAppState(route: .lunarYear(2024))
+
+        let selectedYearNumber = state.selectDefaultYearIfNeeded(
+            from: [2024, 2025, 2026],
+            fallbackYearNumber: 2025
+        )
+
+        #expect(selectedYearNumber == nil)
+        #expect(state.selectedYearNumber == 2024)
+    }
+
+    @Test("clears selected month when route changes")
+    func clearsSelectedMonthWhenRouteChanges() {
+        let state = CalendarAppState(route: .lunarYear(2024), selectedMonthIndex: 12)
+
+        state.route = .lunarYear(2025)
+
+        #expect(state.selectedYearNumber == 2025)
+        #expect(state.selectedMonthIndex == nil)
+    }
+
+    @Test("keeps selected month when route is unchanged")
+    func keepsSelectedMonthWhenRouteIsUnchanged() {
+        let state = CalendarAppState(route: .lunarYear(2024), selectedMonthIndex: 12)
+
+        state.route = .lunarYear(2024)
+
+        #expect(state.selectedMonthIndex == 12)
+    }
+
+    @Test("selects adjacent years within bounds")
+    func selectsAdjacentYearsWithinBounds() {
+        let state = CalendarAppState(route: .lunarYear(2025))
+        let yearNumbers = [2024, 2025, 2026]
+
+        #expect(state.canSelectPreviousYear(in: yearNumbers))
+        #expect(state.canSelectNextYear(in: yearNumbers))
+
+        state.selectPreviousYear(in: yearNumbers)
+        #expect(state.selectedYearNumber == 2024)
+        #expect(!state.canSelectPreviousYear(in: yearNumbers))
+
+        state.selectNextYear(in: yearNumbers)
+        state.selectNextYear(in: yearNumbers)
+        #expect(state.selectedYearNumber == 2026)
+        #expect(!state.canSelectNextYear(in: yearNumbers))
+    }
+
+    @Test("selects default month and adjacent months")
+    func selectsDefaultMonthAndAdjacentMonths() {
+        let state = CalendarAppState()
+        let monthIndexes = [101, 102, 103]
+
+        state.selectDefaultMonthIfNeeded(from: monthIndexes)
+        #expect(state.selectedMonthIndex == 101)
+
+        state.selectNextMonth(in: monthIndexes)
+        #expect(state.selectedMonthIndex == 102)
+
+        state.selectPreviousMonth(in: monthIndexes)
+        #expect(state.selectedMonthIndex == 101)
+        #expect(!state.canSelectPreviousMonth(in: monthIndexes))
+    }
+}

--- a/Sources/ChineseCalendarUI/Tests/CalendarNavigationStateTests.swift
+++ b/Sources/ChineseCalendarUI/Tests/CalendarNavigationStateTests.swift
@@ -1,0 +1,24 @@
+@testable import ChineseCalendarUI
+import SwiftUI
+import Testing
+
+@MainActor
+@Suite("Calendar navigation state")
+struct CalendarNavigationStateTests {
+    @Test("stores route and column visibility independently")
+    func storesRouteAndColumnVisibilityIndependently() {
+        let state = CalendarNavigationState(
+            route: .lunarYear(2025),
+            columnVisibility: .detailOnly
+        )
+
+        #expect(state.route == .lunarYear(2025))
+        #expect(state.columnVisibility == .detailOnly)
+
+        state.route = .dynasty("ming")
+        state.columnVisibility = .all
+
+        #expect(state.route == .dynasty("ming"))
+        #expect(state.columnVisibility == .all)
+    }
+}

--- a/Sources/ChineseCalendarUI/Tests/DynastySelectionStateTests.swift
+++ b/Sources/ChineseCalendarUI/Tests/DynastySelectionStateTests.swift
@@ -1,0 +1,34 @@
+@testable import ChineseCalendarUI
+import Testing
+
+@MainActor
+@Suite("Dynasty selection state")
+struct DynastySelectionStateTests {
+    @Test("selects dynasty, tradition, and orthodox period independently")
+    func selectsDynastyTraditionAndOrthodoxPeriodIndependently() {
+        let state = DynastySelectionState()
+
+        state.selectDynasty(id: "han")
+        state.selectOrthodoxTradition(id: "mainstream")
+        state.selectOrthodoxPeriod(id: "mainstream_han")
+
+        #expect(state.selectedDynastyID == "han")
+        #expect(state.selectedOrthodoxTraditionID == "mainstream")
+        #expect(state.selectedOrthodoxPeriodID == "mainstream_han")
+    }
+
+    @Test("clears dynasty selection group")
+    func clearsDynastySelectionGroup() {
+        let state = DynastySelectionState(
+            selectedDynastyID: "han",
+            selectedOrthodoxTraditionID: "mainstream",
+            selectedOrthodoxPeriodID: "mainstream_han"
+        )
+
+        state.clearSelection()
+
+        #expect(state.selectedDynastyID == nil)
+        #expect(state.selectedOrthodoxTraditionID == nil)
+        #expect(state.selectedOrthodoxPeriodID == nil)
+    }
+}

--- a/Sources/ChineseCalendarUI/Tests/LunarSelectionStateTests.swift
+++ b/Sources/ChineseCalendarUI/Tests/LunarSelectionStateTests.swift
@@ -1,0 +1,127 @@
+@testable import ChineseCalendarUI
+import Testing
+
+@MainActor
+@Suite("Lunar selection state")
+struct LunarSelectionStateTests {
+    @Test("selects fallback year when available")
+    func selectsFallbackYearWhenAvailable() {
+        let state = LunarSelectionState()
+
+        let selectedYearNumber = state.selectDefaultYearIfNeeded(
+            from: [2024, 2025, 2026],
+            fallbackYearNumber: 2025
+        )
+
+        #expect(selectedYearNumber == 2025)
+        #expect(state.selectedYearNumber == 2025)
+    }
+
+    @Test("selects last year when fallback is unavailable")
+    func selectsLastYearWhenFallbackIsUnavailable() {
+        let state = LunarSelectionState()
+
+        let selectedYearNumber = state.selectDefaultYearIfNeeded(
+            from: [2024, 2025, 2026],
+            fallbackYearNumber: 2030
+        )
+
+        #expect(selectedYearNumber == 2026)
+        #expect(state.selectedYearNumber == 2026)
+    }
+
+    @Test("keeps existing valid year")
+    func keepsExistingValidYear() {
+        let state = LunarSelectionState(selectedYearNumber: 2024)
+
+        let selectedYearNumber = state.selectDefaultYearIfNeeded(
+            from: [2024, 2025, 2026],
+            fallbackYearNumber: 2025
+        )
+
+        #expect(selectedYearNumber == nil)
+        #expect(state.selectedYearNumber == 2024)
+    }
+
+    @Test("clears month and day when year changes")
+    func clearsMonthAndDayWhenYearChanges() {
+        let state = LunarSelectionState(
+            selectedYearNumber: 2024,
+            selectedMonthIndex: 12,
+            selectedDayIndex: 345
+        )
+
+        state.selectYear(number: 2025)
+
+        #expect(state.selectedYearNumber == 2025)
+        #expect(state.selectedMonthIndex == nil)
+        #expect(state.selectedDayIndex == nil)
+    }
+
+    @Test("keeps month and day when year is unchanged")
+    func keepsMonthAndDayWhenYearIsUnchanged() {
+        let state = LunarSelectionState(
+            selectedYearNumber: 2024,
+            selectedMonthIndex: 12,
+            selectedDayIndex: 345
+        )
+
+        state.selectYear(number: 2024)
+
+        #expect(state.selectedMonthIndex == 12)
+        #expect(state.selectedDayIndex == 345)
+    }
+
+    @Test("clears selected day when month changes")
+    func clearsSelectedDayWhenMonthChanges() {
+        let state = LunarSelectionState(selectedMonthIndex: 101, selectedDayIndex: 345)
+
+        state.selectMonth(index: 102)
+
+        #expect(state.selectedMonthIndex == 102)
+        #expect(state.selectedDayIndex == nil)
+    }
+
+    @Test("selects adjacent years within bounds")
+    func selectsAdjacentYearsWithinBounds() {
+        let state = LunarSelectionState(selectedYearNumber: 2025)
+        let yearNumbers = [2024, 2025, 2026]
+
+        #expect(state.canSelectPreviousYear(in: yearNumbers))
+        #expect(state.canSelectNextYear(in: yearNumbers))
+
+        state.selectPreviousYear(in: yearNumbers)
+        #expect(state.selectedYearNumber == 2024)
+        #expect(!state.canSelectPreviousYear(in: yearNumbers))
+
+        state.selectNextYear(in: yearNumbers)
+        state.selectNextYear(in: yearNumbers)
+        #expect(state.selectedYearNumber == 2026)
+        #expect(!state.canSelectNextYear(in: yearNumbers))
+    }
+
+    @Test("selects default month and adjacent months")
+    func selectsDefaultMonthAndAdjacentMonths() {
+        let state = LunarSelectionState()
+        let monthIndexes = [101, 102, 103]
+
+        state.selectDefaultMonthIfNeeded(from: monthIndexes)
+        #expect(state.selectedMonthIndex == 101)
+
+        state.selectNextMonth(in: monthIndexes)
+        #expect(state.selectedMonthIndex == 102)
+
+        state.selectPreviousMonth(in: monthIndexes)
+        #expect(state.selectedMonthIndex == 101)
+        #expect(!state.canSelectPreviousMonth(in: monthIndexes))
+    }
+
+    @Test("selects default day when selected day is missing")
+    func selectsDefaultDayWhenSelectedDayIsMissing() {
+        let state = LunarSelectionState(selectedDayIndex: 999)
+
+        state.selectDefaultDayIfNeeded(from: [201, 202, 203])
+
+        #expect(state.selectedDayIndex == 201)
+    }
+}

--- a/Sources/Package.swift
+++ b/Sources/Package.swift
@@ -68,7 +68,8 @@ let package = Package(
                 "ChineseCalendarPersistence",
                 "ChineseCalendarLogging"
             ],
-            path: "ChineseCalendarUI"
+            path: "ChineseCalendarUI",
+            exclude: ["Tests"]
         ),
         .testTarget(
             name: "ChineseCalendarCoreTests",
@@ -84,6 +85,11 @@ let package = Package(
             name: "ChineseCalendarLoggingTests",
             dependencies: ["ChineseCalendarLogging"],
             path: "ChineseCalendarLogging/Tests"
+        ),
+        .testTarget(
+            name: "ChineseCalendarUITests",
+            dependencies: ["ChineseCalendarUI"],
+            path: "ChineseCalendarUI/Tests"
         )
     ]
 )


### PR DESCRIPTION
## Summary
- Add a shared CalendarAppState for navigation, selected year, selected month, and split-view column state
- Wire CalendarHomeView, LunarYearDetailView, and MonthSwitcher through the state object
- Add CalendarAppState tests and register the UI test target

## Verification
- swift test --package-path Sources
- ./Scripts/build_apps.sh