### PR TITLE
Update CI toolchain pins

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,16 +19,16 @@ jobs:
     env:
       XCODEGEN_VERSION: "2.45.3"
       SWIFTFORMAT_VERSION: "0.61.1"
-      SWIFTLINT_VERSION: "0.63.2"
+      SWIFTLINT_VERSION: "0.63.3"
 
     steps:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Select Xcode 26.4.1
+      - name: Select Xcode 26.5
         uses: maxim-lobanov/setup-xcode@v1.7.0
         with:
-          xcode-version: '26.4.1'
+          xcode-version: '26.5'
 
       - name: Install tooling
         run: |
@@ -72,10 +72,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Select Xcode 26.4.1
+      - name: Select Xcode 26.5
         uses: maxim-lobanov/setup-xcode@v1.7.0
         with:
-          xcode-version: '26.4.1'
+          xcode-version: '26.5'
 
       - name: Install XcodeGen
         run: |


### PR DESCRIPTION
## Summary
- bump CI SwiftLint from 0.63.2 to 0.63.3
- move GitHub Actions jobs on macos-26 to Xcode 26.5
- keep SwiftFormat pinned at 0.61.1 because that is still current on the runner image

## Verification
- verified macos-26 runner image README lists Xcode 26.5 as available
- confirmed Homebrew stable SwiftLint is 0.63.3 and SwiftFormat remains 0.61.1
- updated local SwiftLint to 0.63.3
- attempted local Command Line Tools for Xcode 26.5 install via softwareupdate