### PR TITLE
Add local JSONL data admin

### DIFF
--- a/Data/Schemas/calendar_day_bundle.schema.json
+++ b/Data/Schemas/calendar_day_bundle.schema.json
@@ -23,6 +23,7 @@
   "$defs": {
     "calendarDay": {
       "type": "object",
+      "description": "单个绝对日对应的 SwiftData CalendarDay 字段。相关的 CivilDate 和 ChineseLunarDay 共享同一个 dayIndex。",
       "additionalProperties": false,
       "required": [
         "dayIndex",
@@ -30,11 +31,13 @@
       ],
       "properties": {
         "dayIndex": {
-          "type": "integer"
+          "type": "integer",
+          "description": "稳定的绝对日键，从处理后数据集起点开始按 0 递增，用来关联 CalendarDay、CivilDate 和 ChineseLunarDay。"
         },
         "julianDayNumber": {
           "type": "integer",
-          "minimum": 0
+          "minimum": 0,
+          "description": "这个公历/儒略历日期对应的天文学 Julian Day Number。"
         }
       },
       "x-codegen": {
@@ -43,6 +46,7 @@
     },
     "civilDate": {
       "type": "object",
+      "description": "单个绝对日对应的民用日期。具体使用儒略历还是格里历由 calendarStyle 表示。",
       "additionalProperties": false,
       "required": [
         "dayIndex",
@@ -53,20 +57,24 @@
       ],
       "properties": {
         "dayIndex": {
-          "type": "integer"
+          "type": "integer",
+          "description": "稳定的绝对日键，必须与 CalendarDay.dayIndex 相同。"
         },
         "year": {
-          "type": "integer"
+          "type": "integer",
+          "description": "民用年份，使用天文学年份编号；0 年表示公元前 1 年。"
         },
         "month": {
           "type": "integer",
           "minimum": 1,
-          "maximum": 12
+          "maximum": 12,
+          "description": "民用月份序号，范围为 1...12。"
         },
         "dayOfMonth": {
           "type": "integer",
           "minimum": 1,
-          "maximum": 31
+          "maximum": 31,
+          "description": "民用日期中的日序号。"
         },
         "calendarStyle": {
           "type": "string",
@@ -74,6 +82,7 @@
             "julian",
             "gregorian"
           ],
+          "description": "这个日期使用的民用历法系统。格里历采用前的历史日期可能使用 julian。",
           "x-codegen": {
             "swiftType": "CivilCalendarStyle",
             "tsType": "CivilCalendarStyle"
@@ -86,6 +95,7 @@
     },
     "chineseLunarDay": {
       "type": "object",
+      "description": "单个绝对日对应的中国农历日字段，包括所属农历月、月内日序号和日干支。",
       "additionalProperties": false,
       "required": [
         "dayIndex",
@@ -96,25 +106,30 @@
       ],
       "properties": {
         "dayIndex": {
-          "type": "integer"
+          "type": "integer",
+          "description": "稳定的绝对日键，必须与 CalendarDay.dayIndex 相同。"
         },
         "lunarMonthIndex": {
-          "type": "integer"
+          "type": "integer",
+          "description": "稳定的农历月键，对应 ChineseLunarMonth.lunarMonthIndex。"
         },
         "dayNumberInMonth": {
           "type": "integer",
           "minimum": 1,
-          "maximum": 30
+          "maximum": 30,
+          "description": "农历月内的日序号。根据该月 dayCount，范围为 1...29 或 1...30。"
         },
         "dayStemIndex": {
           "type": "integer",
           "minimum": 0,
-          "maximum": 9
+          "maximum": 9,
+          "description": "日的天干索引，0...9 对应 甲、乙、丙、丁、戊、己、庚、辛、壬、癸。"
         },
         "dayBranchIndex": {
           "type": "integer",
           "minimum": 0,
-          "maximum": 11
+          "maximum": 11,
+          "description": "日的地支索引，0...11 对应 子、丑、寅、卯、辰、巳、午、未、申、酉、戌、亥。"
         }
       },
       "x-codegen": {

--- a/Data/Schemas/chinese_date_expression.schema.json
+++ b/Data/Schemas/chinese_date_expression.schema.json
@@ -15,7 +15,8 @@
   "properties": {
     "id": {
       "type": "string",
-      "minLength": 1
+      "minLength": 1,
+      "description": "历史日期表达的稳定标识符。其他记录通过这个 ID 引用该日期表达。"
     },
     "precision": {
       "type": "string",
@@ -26,6 +27,7 @@
         "range",
         "unknown"
       ],
+      "description": "日期表达的精度：year、month、day、range 或 unknown。它决定 index 和 uncertainRange 的解释方式。",
       "x-codegen": {
         "swiftType": "ChineseDatePrecision",
         "tsType": "ChineseDatePrecision"
@@ -35,9 +37,11 @@
       "type": [
         "integer",
         "null"
-      ]
+      ],
+      "description": "在指定精度下的稳定日期索引。precision 为 range 或 unknown 时通常为 null。"
     },
     "uncertainRange": {
+      "description": "不确定日期或范围日期的可选上下界。",
       "anyOf": [
         {
           "$ref": "#/$defs/chineseDateRange"
@@ -48,13 +52,15 @@
       ]
     },
     "sourceText": {
-      "type": "string"
+      "type": "string",
+      "description": "从上游朝代或时期来源中保留下来的可读原文。"
     },
     "note": {
       "type": [
         "string",
         "null"
-      ]
+      ],
+      "description": "导入器对来源解释、边界或不确定性的可选说明。"
     }
   },
   "$defs": {
@@ -69,12 +75,15 @@
       "properties": {
         "id": {
           "type": "string",
-          "minLength": 1
+          "minLength": 1,
+          "description": "不确定日期范围的稳定标识符。"
         },
         "lowerBound": {
+          "description": "不确定日期范围的下界。",
           "$ref": "#/$defs/chineseDateBound"
         },
         "upperBound": {
+          "description": "不确定日期范围的上界；具体是否按开区间解释取决于日期精度和调用场景。",
           "$ref": "#/$defs/chineseDateBound"
         }
       },
@@ -93,7 +102,8 @@
       "properties": {
         "id": {
           "type": "string",
-          "minLength": 1
+          "minLength": 1,
+          "description": "日期范围边界的稳定标识符。"
         },
         "precision": {
           "type": "string",
@@ -104,13 +114,15 @@
             "range",
             "unknown"
           ],
+          "description": "这个日期范围边界的精度。",
           "x-codegen": {
             "swiftType": "ChineseDatePrecision",
             "tsType": "ChineseDatePrecision"
           }
         },
         "index": {
-          "type": "integer"
+          "type": "integer",
+          "description": "这个日期范围边界在指定精度下的稳定日期索引。"
         }
       },
       "x-codegen": {

--- a/Data/Schemas/chinese_lunar_month.schema.json
+++ b/Data/Schemas/chinese_lunar_month.schema.json
@@ -16,18 +16,22 @@
   ],
   "properties": {
     "lunarMonthIndex": {
-      "type": "integer"
+      "type": "integer",
+      "description": "从 0 开始的稳定农历月键。ChineseLunarDay.lunarMonthIndex 用它把日记录关联到这个月。"
     },
     "lunarYearNumber": {
-      "type": "integer"
+      "type": "integer",
+      "description": "这个农历月所属的农历年编号，对应 ChineseLunarYear.lunarYearNumber。"
     },
     "monthNumberInYear": {
       "type": "integer",
       "minimum": 1,
-      "maximum": 12
+      "maximum": 12,
+      "description": "农历年内的传统月份序号。闰月复用前一个普通月的月份序号。"
     },
     "isLeapMonth": {
-      "type": "boolean"
+      "type": "boolean",
+      "description": "这个农历月是否为置闰月。显示为“闰月”还是“后月”由 intercalaryMonthNameStyle 决定。"
     },
     "intercalaryMonthNameStyle": {
       "type": "string",
@@ -35,6 +39,7 @@
         "leap",
         "post"
       ],
+      "description": "置闰月显示规则：leap 表示“闰 X 月”；post 表示秦至汉初颛顼历语境中的“后 X 月”。",
       "x-codegen": {
         "swiftType": "LunarIntercalaryMonthNameStyle",
         "tsType": "LunarIntercalaryMonthNameStyle"
@@ -43,17 +48,20 @@
     "dayCount": {
       "type": "integer",
       "minimum": 29,
-      "maximum": 30
+      "maximum": 30,
+      "description": "这个农历月的天数。29 表示小月，30 表示大月。"
     },
     "monthStemIndex": {
       "type": "integer",
       "minimum": 0,
-      "maximum": 9
+      "maximum": 9,
+      "description": "农历月的天干索引，0...9 对应 甲、乙、丙、丁、戊、己、庚、辛、壬、癸。"
     },
     "monthBranchIndex": {
       "type": "integer",
       "minimum": 0,
-      "maximum": 11
+      "maximum": 11,
+      "description": "农历月的地支索引，0...11 对应 子、丑、寅、卯、辰、巳、午、未、申、酉、戌、亥。"
     }
   },
   "x-codegen": {

--- a/Data/Schemas/chinese_lunar_year.schema.json
+++ b/Data/Schemas/chinese_lunar_year.schema.json
@@ -11,17 +11,20 @@
   ],
   "properties": {
     "lunarYearNumber": {
-      "type": "integer"
+      "type": "integer",
+      "description": "导入后的农历年编号。它是农历月表和应用查询使用的稳定年份键。"
     },
     "yearStemIndex": {
       "type": "integer",
       "minimum": 0,
-      "maximum": 9
+      "maximum": 9,
+      "description": "农历年的天干索引，0...9 对应 甲、乙、丙、丁、戊、己、庚、辛、壬、癸。"
     },
     "yearBranchIndex": {
       "type": "integer",
       "minimum": 0,
-      "maximum": 11
+      "maximum": 11,
+      "description": "农历年的地支索引，0...11 对应 子、丑、寅、卯、辰、巳、午、未、申、酉、戌、亥。"
     }
   },
   "x-codegen": {

--- a/Data/Schemas/dynasty.schema.json
+++ b/Data/Schemas/dynasty.schema.json
@@ -15,31 +15,37 @@
   "properties": {
     "id": {
       "type": "string",
-      "minLength": 1
+      "minLength": 1,
+      "description": "朝代或政权的稳定标识符，供 OrthodoxPeriod.dynastyID 等字段引用。"
     },
     "name": {
       "type": "string",
-      "minLength": 1
+      "minLength": 1,
+      "description": "朝代或政权的完整显示名称。"
     },
     "shortName": {
       "type": [
         "string",
         "null"
-      ]
+      ],
+      "description": "较短的显示名称；没有合适简称时为 null。"
     },
     "claimedStartDateID": {
       "type": "string",
-      "minLength": 1
+      "minLength": 1,
+      "description": "该朝代或政权自身声称/记录的开始日期，引用 ChineseDateExpression.id。"
     },
     "claimedEndDateID": {
       "type": "string",
-      "minLength": 1
+      "minLength": 1,
+      "description": "该朝代或政权自身声称/记录的结束日期，引用 ChineseDateExpression.id。"
     },
     "note": {
       "type": [
         "string",
         "null"
-      ]
+      ],
+      "description": "导入器对来源、拆分规则或历史口径的可选说明。"
     }
   },
   "x-codegen": {

--- a/Data/Schemas/orthodox_boundary.schema.json
+++ b/Data/Schemas/orthodox_boundary.schema.json
@@ -13,21 +13,25 @@
   "properties": {
     "id": {
       "type": "string",
-      "minLength": 1
+      "minLength": 1,
+      "description": "正统时期边界的稳定标识符，供 OrthodoxPeriod.startBoundaryID/endBoundaryID 引用。"
     },
     "traditionID": {
       "type": "string",
-      "minLength": 1
+      "minLength": 1,
+      "description": "该边界所属的正统叙事，引用 OrthodoxTradition.id。"
     },
     "dateExpressionID": {
       "type": "string",
-      "minLength": 1
+      "minLength": 1,
+      "description": "该边界对应的日期表达，引用 ChineseDateExpression.id。"
     },
     "note": {
       "type": [
         "string",
         "null"
-      ]
+      ],
+      "description": "该边界的可选说明。"
     }
   },
   "x-codegen": {

--- a/Data/Schemas/orthodox_period.schema.json
+++ b/Data/Schemas/orthodox_period.schema.json
@@ -18,40 +18,49 @@
   "properties": {
     "id": {
       "type": "string",
-      "minLength": 1
+      "minLength": 1,
+      "description": "正统时期记录的稳定标识符。"
     },
     "traditionID": {
       "type": "string",
-      "minLength": 1
+      "minLength": 1,
+      "description": "该正统时期所属的正统叙事，引用 OrthodoxTradition.id。"
     },
     "dynastyID": {
       "type": "string",
-      "minLength": 1
+      "minLength": 1,
+      "description": "该正统时期对应的朝代或政权，引用 Dynasty.id。"
     },
     "startBoundaryID": {
       "type": "string",
-      "minLength": 1
+      "minLength": 1,
+      "description": "该正统时期的开始边界，引用 OrthodoxBoundary.id。"
     },
     "endBoundaryID": {
       "type": "string",
-      "minLength": 1
+      "minLength": 1,
+      "description": "该正统时期的结束边界，引用 OrthodoxBoundary.id。正统时期按 [start, end) 半开区间理解。"
     },
     "sequenceIndex": {
       "type": "integer",
-      "minimum": 0
+      "minimum": 0,
+      "description": "正统叙事中的全局顺序，从 0 开始连续递增。"
     },
     "segmentIndex": {
       "type": "integer",
-      "minimum": 0
+      "minimum": 0,
+      "description": "正统叙事中的分段顺序，用来保留三国、五代等叙事分组。"
     },
     "segmentName": {
-      "type": "string"
+      "type": "string",
+      "description": "正统叙事分段名称，例如 秦、汉、三国、晋、南朝、五代、宋。"
     },
     "note": {
       "type": [
         "string",
         "null"
-      ]
+      ],
+      "description": "该正统时期的可选说明。"
     }
   },
   "x-codegen": {

--- a/Data/Schemas/orthodox_tradition.schema.json
+++ b/Data/Schemas/orthodox_tradition.schema.json
@@ -12,17 +12,20 @@
   "properties": {
     "id": {
       "type": "string",
-      "minLength": 1
+      "minLength": 1,
+      "description": "正统叙事的稳定标识符，供 OrthodoxBoundary 和 OrthodoxPeriod 引用。"
     },
     "name": {
       "type": "string",
-      "minLength": 1
+      "minLength": 1,
+      "description": "正统叙事的显示名称。"
     },
     "note": {
       "type": [
         "string",
         "null"
-      ]
+      ],
+      "description": "该正统叙事的可选说明。"
     }
   },
   "x-codegen": {

--- a/Scripts/BuildChineseCalendarSeedStore/generate_seed_store_if_needed.sh
+++ b/Scripts/BuildChineseCalendarSeedStore/generate_seed_store_if_needed.sh
@@ -25,10 +25,7 @@ seed_store_format_version() {
 
 source_data_is_newer_than_seed_manifest() {
     [[ "$INPUT_DIR/manifest.json" -nt "$SEED_MANIFEST" ]] && return 0
-    [[ "$INPUT_DIR/chinese_lunar_years.jsonl" -nt "$SEED_MANIFEST" ]] && return 0
-    [[ "$INPUT_DIR/chinese_lunar_months.jsonl" -nt "$SEED_MANIFEST" ]] && return 0
-
-    [[ -n "$(find "$INPUT_DIR/calendar_days" -name calendar_days.jsonl -newer "$SEED_MANIFEST" -print -quit)" ]]
+    [[ -n "$(find "$INPUT_DIR" -name '*.jsonl' -newer "$SEED_MANIFEST" -print -quit)" ]]
 }
 
 if [[ -f "$SEED_STORE" && -f "$SEED_MANIFEST" ]]; then

--- a/Scripts/DataAdmin/README.md
+++ b/Scripts/DataAdmin/README.md
@@ -1,0 +1,65 @@
+# DataAdmin
+
+Local web editor for the processed JSONL facts that feed the SwiftData seed store.
+
+## Run
+
+From the repository root:
+
+```bash
+Scripts/DataAdmin/server.mjs
+```
+
+Then open:
+
+```text
+http://127.0.0.1:5177
+```
+
+Optional port override:
+
+```bash
+Scripts/DataAdmin/server.mjs --port 5180
+```
+
+## Data Flow
+
+```mermaid
+flowchart LR
+  raw[Data/Raw/ChineseCalendar] --> generated[Data/Processed/calendar_days]
+  generated --> jsonl[Data/Processed/swiftdata_import/*.jsonl]
+  jsonl --> admin[DataAdmin preview/edit]
+  admin --> jsonl
+  jsonl --> seed[Apps/Shared/Resources/ChineseCalendarSeedStore.bundle/ChineseCalendar.sqlite]
+```
+
+The editor writes one JSON object per JSONL line, so normal `git diff` remains useful during review.
+SQLite is treated as generated output and should be rebuilt from JSONL.
+
+## Supported Files
+
+- `chinese_lunar_years.jsonl`
+- `chinese_lunar_months.jsonl`
+- `calendar_days/<year>/calendar_days.jsonl`
+- `dynasties.jsonl`
+- `chinese_date_expressions.jsonl`
+- `orthodox_traditions.jsonl`
+- `orthodox_boundaries.jsonl`
+- `orthodox_periods.jsonl`
+
+## Checks
+
+The web UI exposes the same local commands used by the data pipeline:
+
+```bash
+Scripts/DataSchemas/generate_schema_artifacts.swift --check
+Scripts/DataSchemas/validate_swiftdata_import.swift
+Scripts/ImportChineseCalendar/generate_swiftdata_import.swift --validate-only
+Scripts/ImportChineseCalendar/generate_dynasty_periods.swift --validate-only
+```
+
+The `Build SQLite` button runs:
+
+```bash
+Scripts/BuildChineseCalendarSeedStore/generate_seed_store_if_needed.sh
+```

--- a/Scripts/DataAdmin/public/app.js
+++ b/Scripts/DataAdmin/public/app.js
@@ -1,0 +1,436 @@
+const pageSize = 200;
+
+const state = {
+  meta: null,
+  datasetID: "calendar-days",
+  year: null,
+  query: "",
+  offset: 0,
+  selected: null,
+  recordsResponse: null
+};
+
+const elements = {
+  dataRoot: document.querySelector("#data-root"),
+  datasetList: document.querySelector("#dataset-list"),
+  manifestSummary: document.querySelector("#manifest-summary"),
+  yearField: document.querySelector("#year-field"),
+  yearSelect: document.querySelector("#year-select"),
+  queryInput: document.querySelector("#query-input"),
+  reloadButton: document.querySelector("#reload-button"),
+  diffButton: document.querySelector("#diff-button"),
+  validateButton: document.querySelector("#validate-button"),
+  buildButton: document.querySelector("#build-button"),
+  datasetTitle: document.querySelector("#dataset-title"),
+  filePath: document.querySelector("#file-path"),
+  recordCount: document.querySelector("#record-count"),
+  recordList: document.querySelector("#record-list"),
+  previousButton: document.querySelector("#previous-button"),
+  nextButton: document.querySelector("#next-button"),
+  pageLabel: document.querySelector("#page-label"),
+  editorTitle: document.querySelector("#editor-title"),
+  editorSubtitle: document.querySelector("#editor-subtitle"),
+  saveButton: document.querySelector("#save-button"),
+  readablePreview: document.querySelector("#readable-preview"),
+  jsonEditor: document.querySelector("#json-editor"),
+  editorMessage: document.querySelector("#editor-message"),
+  commandOutput: document.querySelector("#command-output"),
+  outputSubtitle: document.querySelector("#output-subtitle"),
+  clearOutputButton: document.querySelector("#clear-output-button")
+};
+
+init().catch((error) => {
+  appendOutput(`Failed to load Data Admin.\n${error.message}`);
+});
+
+async function init() {
+  bindEvents();
+  state.meta = await getJSON("/api/meta");
+  state.year = defaultYear(state.meta.calendarYears);
+  renderMeta();
+  await loadRecords();
+}
+
+function bindEvents() {
+  elements.yearSelect.addEventListener("change", async () => {
+    state.year = Number(elements.yearSelect.value);
+    state.offset = 0;
+    await loadRecords();
+  });
+
+  elements.queryInput.addEventListener("input", debounce(async () => {
+    state.query = elements.queryInput.value;
+    state.offset = 0;
+    await loadRecords();
+  }, 220));
+
+  elements.reloadButton.addEventListener("click", async () => {
+    await loadRecords();
+  });
+
+  elements.previousButton.addEventListener("click", async () => {
+    state.offset = Math.max(0, state.offset - pageSize);
+    await loadRecords();
+  });
+
+  elements.nextButton.addEventListener("click", async () => {
+    state.offset += pageSize;
+    await loadRecords();
+  });
+
+  elements.saveButton.addEventListener("click", async () => {
+    await saveSelectedRecord();
+  });
+
+  elements.diffButton.addEventListener("click", async () => {
+    await showDiff();
+  });
+
+  elements.validateButton.addEventListener("click", async () => {
+    await runCommand("/api/commands/validate", "Validating JSONL artifacts...");
+  });
+
+  elements.buildButton.addEventListener("click", async () => {
+    await runCommand("/api/commands/build-seed", "Generating SwiftData SQLite seed store...");
+  });
+
+  elements.clearOutputButton.addEventListener("click", () => {
+    elements.commandOutput.textContent = "";
+  });
+}
+
+function renderMeta() {
+  elements.dataRoot.textContent = state.meta.dataRoot;
+  elements.datasetList.replaceChildren(...state.meta.datasets.map(renderDatasetButton));
+  renderManifest();
+  renderYearSelect();
+}
+
+function renderDatasetButton(dataset) {
+  const button = document.createElement("button");
+  button.type = "button";
+  button.className = dataset.id === state.datasetID ? "dataset-button active" : "dataset-button";
+  button.innerHTML = `<strong>${escapeHTML(dataset.label)}</strong><code>${escapeHTML(dataset.recordType)}</code><span>${escapeHTML(dataset.detail)}</span>`;
+  button.addEventListener("click", async () => {
+    state.datasetID = dataset.id;
+    state.offset = 0;
+    state.selected = null;
+    elements.datasetList.replaceChildren(...state.meta.datasets.map(renderDatasetButton));
+    await loadRecords();
+  });
+  return button;
+}
+
+function renderManifest() {
+  const manifest = state.meta.manifest;
+  if (!manifest) {
+    elements.manifestSummary.textContent = "No manifest found.";
+    return;
+  }
+
+  const entries = [
+    ["Range", `${manifest.startYear}...${manifest.endYear}`],
+    ["Days", formatNumber(manifest.totalCalendarDays)],
+    ["Years", formatNumber(manifest.totalChineseLunarYears)],
+    ["Months", formatNumber(manifest.totalChineseLunarMonths)],
+    ["Dynasties", formatNumber(manifest.totalDynasties)],
+    ["Generated", manifest.generatedAt],
+    ["Commit", manifest.sourceUpstreamCommit]
+  ];
+
+  elements.manifestSummary.replaceChildren(...entries.flatMap(([key, value]) => {
+    const dt = document.createElement("dt");
+    dt.textContent = key;
+    const dd = document.createElement("dd");
+    dd.textContent = value ?? "-";
+    return [dt, dd];
+  }));
+}
+
+function renderYearSelect() {
+  const years = state.meta.calendarYears;
+  const fragment = document.createDocumentFragment();
+  for (const year of years) {
+    const option = document.createElement("option");
+    option.value = String(year);
+    option.textContent = String(year);
+    if (year === state.year) {
+      option.selected = true;
+    }
+    fragment.append(option);
+  }
+  elements.yearSelect.replaceChildren(fragment);
+}
+
+async function loadRecords() {
+  const dataset = selectedDataset();
+  elements.yearField.classList.toggle("hidden", !dataset.yearScoped);
+  elements.saveButton.disabled = true;
+  elements.jsonEditor.disabled = true;
+  elements.jsonEditor.value = "";
+  setEditorMessage("Loading records...");
+
+  const params = new URLSearchParams({
+    dataset: state.datasetID,
+    offset: String(state.offset),
+    limit: String(pageSize),
+    query: state.query
+  });
+  if (dataset.yearScoped) {
+    params.set("year", String(state.year));
+  }
+
+  const response = await getJSON(`/api/records?${params}`);
+  state.recordsResponse = response;
+  state.selected = null;
+  renderRecords(response);
+  setEditorEmpty();
+}
+
+function renderRecords(response) {
+  elements.datasetTitle.textContent = `${response.dataset.label} · ${response.dataset.recordType}`;
+  elements.filePath.textContent = response.path;
+  elements.recordCount.textContent = formatNumber(response.matchedCount);
+
+  if (response.records.length === 0) {
+    const empty = document.createElement("div");
+    empty.className = "message";
+    empty.textContent = "No records match the current filter.";
+    elements.recordList.replaceChildren(empty);
+  } else {
+    elements.recordList.replaceChildren(...response.records.map(renderRecordItem));
+  }
+
+  elements.previousButton.disabled = response.offset === 0;
+  elements.nextButton.disabled = response.offset + response.limit >= response.matchedCount;
+  const first = response.matchedCount === 0 ? 0 : response.offset + 1;
+  const last = Math.min(response.offset + response.records.length, response.matchedCount);
+  elements.pageLabel.textContent = `${formatNumber(first)} - ${formatNumber(last)} of ${formatNumber(response.matchedCount)}`;
+}
+
+function renderRecordItem(record) {
+  const button = document.createElement("button");
+  button.type = "button";
+  button.className = "record-item";
+  button.innerHTML = `
+    <span class="record-title">${escapeHTML(record.summary)}</span>
+    <span class="record-meta"><span>line ${record.lineNumber}</span><span>${escapeHTML(String(record.key ?? ""))}</span></span>
+  `;
+  button.addEventListener("click", () => selectRecord(record, button));
+  return button;
+}
+
+function selectRecord(record, button) {
+  state.selected = record;
+  for (const item of elements.recordList.querySelectorAll(".record-item")) {
+    item.classList.remove("active");
+  }
+  button.classList.add("active");
+
+  elements.editorTitle.textContent = `Line ${record.lineNumber}`;
+  elements.editorSubtitle.textContent = `${state.recordsResponse.path} · ${record.summary}`;
+  elements.jsonEditor.disabled = false;
+  elements.saveButton.disabled = false;
+  elements.jsonEditor.value = prettyJSON(record.raw);
+  renderReadablePreview(record);
+  setEditorMessage(record.parseError ? record.parseError : "Ready.", Boolean(record.parseError));
+}
+
+function setEditorEmpty() {
+  elements.editorTitle.textContent = "Select a record";
+  elements.editorSubtitle.textContent = "No record selected.";
+  elements.jsonEditor.value = "";
+  elements.readablePreview.replaceChildren(...emptyReadableItem("请选择一条记录。"));
+  elements.jsonEditor.disabled = true;
+  elements.saveButton.disabled = true;
+  setEditorMessage("Ready.");
+}
+
+async function saveSelectedRecord() {
+  if (!state.selected) {
+    return;
+  }
+
+  let record;
+  try {
+    record = JSON.parse(elements.jsonEditor.value);
+  } catch (error) {
+    setEditorMessage(`Invalid JSON: ${error.message}`, true);
+    return;
+  }
+
+  const payload = {
+    dataset: state.datasetID,
+    year: selectedDataset().yearScoped ? state.year : null,
+    lineNumber: state.selected.lineNumber,
+    record
+  };
+
+  elements.saveButton.disabled = true;
+  setEditorMessage("Saving...");
+
+  try {
+    const response = await putJSON("/api/record", payload);
+    state.selected = {
+      ...state.selected,
+      raw: response.raw,
+      record: response.record,
+      summary: response.summary,
+      key: valueAtPath(response.record, selectedDataset().keyPath),
+      parseError: null
+    };
+    setEditorMessage("Saved. Run validation before generating SQLite.");
+    await loadRecords();
+  } catch (error) {
+    setEditorMessage(error.message, true);
+  } finally {
+    elements.saveButton.disabled = false;
+  }
+}
+
+function renderReadablePreview(record) {
+  const dataset = selectedDataset();
+  const items = Array.isArray(record.readable) ? record.readable : [];
+  if (items.length === 0) {
+    elements.readablePreview.replaceChildren(...emptyReadableItem("没有可读预览。"));
+    return;
+  }
+
+  elements.readablePreview.replaceChildren(...items.flatMap((entry) => {
+    const dt = document.createElement("dt");
+    dt.textContent = entry.label;
+    const dd = document.createElement("dd");
+    dd.textContent = entry.value;
+    const description = entry.path ? dataset.schema?.[entry.path] : null;
+    if (description) {
+      const small = document.createElement("small");
+      small.textContent = description;
+      dd.append(small);
+    }
+    return [dt, dd];
+  }));
+}
+
+function emptyReadableItem(message) {
+  const dt = document.createElement("dt");
+  dt.textContent = "状态";
+  const dd = document.createElement("dd");
+  dd.textContent = message;
+  return [dt, dd];
+}
+
+async function showDiff() {
+  const dataset = selectedDataset();
+  const params = new URLSearchParams({ dataset: state.datasetID });
+  if (dataset.yearScoped) {
+    params.set("year", String(state.year));
+  }
+
+  appendOutput(`$ git diff -- ${dataset.yearScoped ? `calendar_days/${state.year}/calendar_days.jsonl` : dataset.detail}\n`);
+  const response = await getJSON(`/api/diff?${params}`);
+  appendOutput(response.diff || "No diff for this JSONL file.");
+}
+
+async function runCommand(endpoint, heading) {
+  appendOutput(`${heading}\n`);
+  setCommandButtonsDisabled(true);
+  try {
+    const response = await postJSON(endpoint, {});
+    for (const result of response.results) {
+      appendOutput(`\n$ ${result.command} ${result.args.join(" ")}\n${result.output || "(no output)"}\nstatus: ${result.status}`);
+    }
+    appendOutput(response.ok ? "\nDone.\n" : "\nCommand failed.\n");
+  } catch (error) {
+    appendOutput(`\n${error.message}\n`);
+  } finally {
+    setCommandButtonsDisabled(false);
+  }
+}
+
+function setCommandButtonsDisabled(disabled) {
+  elements.validateButton.disabled = disabled;
+  elements.buildButton.disabled = disabled;
+  elements.diffButton.disabled = disabled;
+}
+
+function selectedDataset() {
+  return state.meta.datasets.find((dataset) => dataset.id === state.datasetID);
+}
+
+function defaultYear(years) {
+  if (years.includes(2024)) {
+    return 2024;
+  }
+  return years[Math.max(0, Math.floor(years.length / 2))] ?? 0;
+}
+
+function prettyJSON(raw) {
+  try {
+    return JSON.stringify(JSON.parse(raw), null, 2);
+  } catch {
+    return raw;
+  }
+}
+
+function setEditorMessage(message, isError = false) {
+  elements.editorMessage.textContent = message;
+  elements.editorMessage.classList.toggle("error", isError);
+}
+
+function appendOutput(text) {
+  const separator = elements.commandOutput.textContent.length > 0 && !elements.commandOutput.textContent.endsWith("\n") ? "\n" : "";
+  elements.commandOutput.textContent += `${separator}${text}`;
+  elements.commandOutput.scrollTop = elements.commandOutput.scrollHeight;
+}
+
+async function getJSON(url) {
+  return requestJSON(url);
+}
+
+async function postJSON(url, body) {
+  return requestJSON(url, { method: "POST", body: JSON.stringify(body) });
+}
+
+async function putJSON(url, body) {
+  return requestJSON(url, { method: "PUT", body: JSON.stringify(body) });
+}
+
+async function requestJSON(url, options = {}) {
+  const response = await fetch(url, {
+    headers: { "Content-Type": "application/json" },
+    ...options
+  });
+  const value = await response.json();
+  if (!response.ok) {
+    throw new Error(value.error ?? `Request failed: ${response.status}`);
+  }
+  return value;
+}
+
+function debounce(fn, delay) {
+  let timeout = null;
+  return (...args) => {
+    clearTimeout(timeout);
+    timeout = setTimeout(() => fn(...args), delay);
+  };
+}
+
+function escapeHTML(value) {
+  return String(value).replace(/[&<>"]/g, (character) => ({
+    "&": "&amp;",
+    "<": "&lt;",
+    ">": "&gt;",
+    "\"": "&quot;"
+  })[character]);
+}
+
+function formatNumber(value) {
+  if (value === null || value === undefined) {
+    return "-";
+  }
+  return Number(value).toLocaleString("en-US");
+}
+
+function valueAtPath(record, keyPath) {
+  return keyPath.split(".").reduce((value, key) => value?.[key], record) ?? null;
+}

--- a/Scripts/DataAdmin/public/index.html
+++ b/Scripts/DataAdmin/public/index.html
@@ -1,0 +1,96 @@
+<!doctype html>
+<html lang="zh-Hans">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Chinese Calendar Data Admin</title>
+    <link rel="stylesheet" href="/styles.css">
+  </head>
+  <body>
+    <main class="app-shell">
+      <aside class="sidebar" aria-label="数据集">
+        <div class="brand-block">
+          <h1>Data Admin</h1>
+          <p id="data-root">Loading...</p>
+        </div>
+
+        <nav id="dataset-list" class="dataset-list"></nav>
+
+        <section class="manifest-panel" aria-label="数据摘要">
+          <h2>Manifest</h2>
+          <dl id="manifest-summary"></dl>
+        </section>
+      </aside>
+
+      <section class="workspace">
+        <header class="toolbar">
+          <div class="filters">
+            <label class="field compact" id="year-field">
+              <span>Year</span>
+              <select id="year-select"></select>
+            </label>
+            <label class="field search-field">
+              <span>Search</span>
+              <input id="query-input" type="search" placeholder="id, 日期, dynasty..." autocomplete="off">
+            </label>
+          </div>
+          <div class="actions" aria-label="命令">
+            <button id="reload-button" type="button" title="Reload records">Reload</button>
+            <button id="diff-button" type="button" title="Show git diff for this JSONL">Diff</button>
+            <button id="validate-button" type="button" title="Validate current JSONL artifacts">Validate</button>
+            <button id="build-button" type="button" title="Generate SwiftData SQLite from JSONL">Build SQLite</button>
+          </div>
+        </header>
+
+        <section class="content-grid">
+          <section class="record-panel" aria-label="记录列表">
+            <div class="panel-heading">
+              <div>
+                <h2 id="dataset-title">Records</h2>
+                <p id="file-path">-</p>
+              </div>
+              <div id="record-count" class="counter">0</div>
+            </div>
+            <div id="record-list" class="record-list"></div>
+            <div class="pager">
+              <button id="previous-button" type="button">Previous</button>
+              <span id="page-label">0 - 0</span>
+              <button id="next-button" type="button">Next</button>
+            </div>
+          </section>
+
+          <section class="editor-panel" aria-label="JSONL 编辑器">
+            <div class="panel-heading editor-heading">
+              <div>
+                <h2 id="editor-title">Select a record</h2>
+                <p id="editor-subtitle">No record selected.</p>
+              </div>
+              <button id="save-button" type="button" disabled>Save Line</button>
+            </div>
+            <div class="editor-body">
+              <section class="readable-panel" aria-label="可读预览">
+                <h3>可读预览</h3>
+                <dl id="readable-preview"></dl>
+              </section>
+              <textarea id="json-editor" spellcheck="false" disabled></textarea>
+            </div>
+            <div id="editor-message" class="message" role="status"></div>
+          </section>
+        </section>
+
+        <section class="output-panel" aria-label="命令输出">
+          <div class="panel-heading">
+            <div>
+              <h2>Output</h2>
+              <p id="output-subtitle">Command output</p>
+            </div>
+            <button id="clear-output-button" type="button">Clear</button>
+          </div>
+          <pre id="command-output"></pre>
+        </section>
+      </section>
+    </main>
+
+    <script type="module" src="/app.js"></script>
+  </body>
+</html>

--- a/Scripts/DataAdmin/public/styles.css
+++ b/Scripts/DataAdmin/public/styles.css
@@ -1,0 +1,459 @@
+:root {
+  color-scheme: light;
+  --bg: #f6f7f9;
+  --panel: #ffffff;
+  --panel-soft: #f0f4f7;
+  --ink: #202429;
+  --muted: #68707a;
+  --line: #d8dee5;
+  --accent: #246b5a;
+  --accent-strong: #17483d;
+  --danger: #b42318;
+  --focus: #c7a34a;
+  --code: #17202a;
+  --shadow: 0 1px 3px rgba(24, 31, 38, 0.08);
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-width: 980px;
+  color: var(--ink);
+  background: var(--bg);
+}
+
+button,
+input,
+select,
+textarea {
+  font: inherit;
+}
+
+button {
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  padding: 7px 11px;
+  color: var(--ink);
+  background: #fff;
+  cursor: pointer;
+}
+
+button:hover:not(:disabled) {
+  border-color: #aeb8c2;
+  background: #f9fafb;
+}
+
+button:disabled {
+  cursor: not-allowed;
+  opacity: 0.55;
+}
+
+button.primary,
+#save-button {
+  border-color: var(--accent);
+  color: #fff;
+  background: var(--accent);
+}
+
+button.primary:hover:not(:disabled),
+#save-button:hover:not(:disabled) {
+  border-color: var(--accent-strong);
+  background: var(--accent-strong);
+}
+
+.app-shell {
+  display: grid;
+  grid-template-columns: 276px minmax(0, 1fr);
+  min-height: 100vh;
+}
+
+.sidebar {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  border-right: 1px solid var(--line);
+  padding: 20px 16px;
+  background: #fbfcfd;
+}
+
+.brand-block h1 {
+  margin: 0;
+  font-size: 22px;
+  line-height: 1.2;
+  letter-spacing: 0;
+}
+
+.brand-block p,
+.panel-heading p,
+.manifest-panel dd,
+.manifest-panel dt,
+.field span,
+.record-meta,
+.message {
+  color: var(--muted);
+}
+
+.brand-block p {
+  margin: 8px 0 0;
+  overflow-wrap: anywhere;
+  font-size: 12px;
+  line-height: 1.4;
+}
+
+.dataset-list {
+  display: grid;
+  gap: 6px;
+}
+
+.dataset-button {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 4px 8px;
+  width: 100%;
+  padding: 10px;
+  text-align: left;
+}
+
+.dataset-button.active {
+  border-color: var(--accent);
+  background: #e8f2ef;
+}
+
+.dataset-button strong {
+  font-size: 14px;
+}
+
+.dataset-button span {
+  grid-column: 1 / -1;
+  color: var(--muted);
+  font-size: 12px;
+}
+
+.dataset-button code {
+  color: var(--accent-strong);
+  font-size: 12px;
+}
+
+.manifest-panel {
+  margin-top: auto;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  padding: 12px;
+  background: var(--panel);
+}
+
+.manifest-panel h2 {
+  margin: 0 0 10px;
+  font-size: 13px;
+}
+
+.manifest-panel dl {
+  display: grid;
+  grid-template-columns: minmax(74px, auto) 1fr;
+  gap: 7px 10px;
+  margin: 0;
+  font-size: 12px;
+}
+
+.manifest-panel dd {
+  margin: 0;
+  overflow-wrap: anywhere;
+  text-align: right;
+}
+
+.workspace {
+  display: grid;
+  grid-template-rows: auto minmax(420px, 1fr) 220px;
+  gap: 14px;
+  padding: 16px;
+  min-width: 0;
+}
+
+.toolbar,
+.record-panel,
+.editor-panel,
+.output-panel {
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--panel);
+  box-shadow: var(--shadow);
+}
+
+.toolbar {
+  display: flex;
+  align-items: end;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 12px;
+}
+
+.filters,
+.actions {
+  display: flex;
+  align-items: end;
+  gap: 10px;
+}
+
+.field {
+  display: grid;
+  gap: 5px;
+  min-width: 160px;
+}
+
+.field.compact {
+  width: 116px;
+  min-width: 116px;
+}
+
+.search-field {
+  width: min(42vw, 520px);
+}
+
+.field span {
+  font-size: 12px;
+}
+
+input,
+select {
+  height: 36px;
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  padding: 0 10px;
+  background: #fff;
+}
+
+input:focus,
+select:focus,
+textarea:focus,
+button:focus-visible {
+  outline: 2px solid var(--focus);
+  outline-offset: 1px;
+}
+
+.content-grid {
+  display: grid;
+  grid-template-columns: minmax(380px, 43%) minmax(0, 1fr);
+  gap: 14px;
+  min-height: 0;
+}
+
+.record-panel,
+.editor-panel,
+.output-panel {
+  display: grid;
+  min-height: 0;
+}
+
+.record-panel {
+  grid-template-rows: auto minmax(0, 1fr) auto;
+}
+
+.editor-panel {
+  grid-template-rows: auto minmax(0, 1fr) auto;
+}
+
+.output-panel {
+  grid-template-rows: auto minmax(0, 1fr);
+}
+
+.panel-heading {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  border-bottom: 1px solid var(--line);
+  padding: 12px;
+}
+
+.panel-heading h2 {
+  margin: 0;
+  font-size: 15px;
+  line-height: 1.25;
+}
+
+.panel-heading p {
+  margin: 4px 0 0;
+  overflow-wrap: anywhere;
+  font-size: 12px;
+}
+
+.counter {
+  min-width: 58px;
+  border-radius: 999px;
+  padding: 5px 9px;
+  color: var(--accent-strong);
+  background: #e8f2ef;
+  text-align: center;
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.record-list {
+  overflow: auto;
+  padding: 8px;
+}
+
+.record-item {
+  display: grid;
+  gap: 5px;
+  width: 100%;
+  border: 1px solid transparent;
+  border-radius: 6px;
+  padding: 9px;
+  text-align: left;
+  background: transparent;
+}
+
+.record-item:hover {
+  border-color: var(--line);
+  background: #f9fafb;
+}
+
+.record-item.active {
+  border-color: var(--accent);
+  background: #e8f2ef;
+}
+
+.record-title {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 13px;
+  font-weight: 700;
+}
+
+.record-meta {
+  display: flex;
+  gap: 8px;
+  min-width: 0;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+  font-size: 11px;
+}
+
+.record-meta span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.pager {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  border-top: 1px solid var(--line);
+  padding: 10px 12px;
+  color: var(--muted);
+  font-size: 12px;
+}
+
+.editor-heading {
+  align-items: start;
+}
+
+.editor-body {
+  display: grid;
+  grid-template-rows: auto minmax(0, 1fr);
+  min-height: 0;
+}
+
+.readable-panel {
+  border-bottom: 1px solid var(--line);
+  padding: 12px 14px;
+  background: #fbfcfd;
+}
+
+.readable-panel h3 {
+  margin: 0 0 8px;
+  font-size: 13px;
+  line-height: 1.2;
+}
+
+.readable-panel dl {
+  display: grid;
+  grid-template-columns: minmax(90px, auto) 1fr;
+  gap: 7px 12px;
+  margin: 0;
+  font-size: 12px;
+}
+
+.readable-panel dt {
+  color: var(--muted);
+}
+
+.readable-panel dd {
+  margin: 0;
+  min-width: 0;
+  overflow-wrap: anywhere;
+}
+
+.readable-panel small {
+  display: block;
+  margin-top: 2px;
+  color: var(--muted);
+  line-height: 1.35;
+}
+
+#json-editor {
+  width: 100%;
+  height: 100%;
+  min-height: 0;
+  resize: none;
+  border: 0;
+  padding: 14px;
+  color: var(--code);
+  background: #fbfcfd;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+  font-size: 12px;
+  line-height: 1.55;
+  tab-size: 2;
+}
+
+.message {
+  min-height: 36px;
+  border-top: 1px solid var(--line);
+  padding: 10px 12px;
+  font-size: 12px;
+}
+
+.message.error {
+  color: var(--danger);
+}
+
+#command-output {
+  margin: 0;
+  overflow: auto;
+  padding: 12px;
+  color: var(--code);
+  background: #fbfcfd;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+  font-size: 12px;
+  line-height: 1.45;
+  white-space: pre-wrap;
+}
+
+.hidden {
+  display: none;
+}
+
+@media (max-width: 1100px) {
+  body {
+    min-width: 760px;
+  }
+
+  .app-shell {
+    grid-template-columns: 230px minmax(0, 1fr);
+  }
+
+  .content-grid {
+    grid-template-columns: 1fr;
+    grid-template-rows: minmax(300px, 40vh) minmax(360px, 1fr);
+  }
+
+  .workspace {
+    grid-template-rows: auto minmax(720px, 1fr) 220px;
+  }
+}

--- a/Scripts/DataAdmin/server.mjs
+++ b/Scripts/DataAdmin/server.mjs
@@ -1,0 +1,838 @@
+#!/usr/bin/env node
+import { createReadStream } from "node:fs";
+import { mkdir, readFile, readdir, rename, stat, writeFile } from "node:fs/promises";
+import http from "node:http";
+import path from "node:path";
+import { spawn } from "node:child_process";
+import { createInterface } from "node:readline";
+import { fileURLToPath } from "node:url";
+
+const scriptDirectory = path.dirname(fileURLToPath(import.meta.url));
+const repositoryRoot = path.resolve(scriptDirectory, "../..");
+const dataRoot = path.join(repositoryRoot, "Data/Processed/swiftdata_import");
+const publicRoot = path.join(scriptDirectory, "public");
+const schemasRoot = path.join(repositoryRoot, "Data/Schemas");
+
+const heavenlyStems = ["甲", "乙", "丙", "丁", "戊", "己", "庚", "辛", "壬", "癸"];
+const earthlyBranches = ["子", "丑", "寅", "卯", "辰", "巳", "午", "未", "申", "酉", "戌", "亥"];
+const zodiacAnimals = ["鼠", "牛", "虎", "兔", "龙", "蛇", "马", "羊", "猴", "鸡", "狗", "猪"];
+
+const datasets = [
+  {
+    id: "lunar-years",
+    label: "年",
+    detail: "ChineseLunarYear",
+    recordType: "ChineseLunarYearRecord",
+    schema: "chinese_lunar_year.schema.json",
+    file: "chinese_lunar_years.jsonl",
+    keyPath: "lunarYearNumber"
+  },
+  {
+    id: "lunar-months",
+    label: "月",
+    detail: "ChineseLunarMonth",
+    recordType: "ChineseLunarMonthRecord",
+    schema: "chinese_lunar_month.schema.json",
+    file: "chinese_lunar_months.jsonl",
+    keyPath: "lunarMonthIndex"
+  },
+  {
+    id: "calendar-days",
+    label: "日",
+    detail: "CalendarDayBundleByCivilYear",
+    recordType: "CalendarDayBundleRecord",
+    schema: "calendar_day_bundle.schema.json",
+    yearScoped: true,
+    keyPath: "calendarDay.dayIndex"
+  },
+  {
+    id: "dynasties",
+    label: "朝代",
+    detail: "Dynasty",
+    recordType: "DynastyRecord",
+    schema: "dynasty.schema.json",
+    file: "dynasties.jsonl",
+    keyPath: "id"
+  },
+  {
+    id: "date-expressions",
+    label: "日期表达",
+    detail: "ChineseDateExpression",
+    recordType: "ChineseDateExpressionRecord",
+    schema: "chinese_date_expression.schema.json",
+    file: "chinese_date_expressions.jsonl",
+    keyPath: "id"
+  },
+  {
+    id: "orthodox-traditions",
+    label: "正统叙事",
+    detail: "OrthodoxTradition",
+    recordType: "OrthodoxTraditionRecord",
+    schema: "orthodox_tradition.schema.json",
+    file: "orthodox_traditions.jsonl",
+    keyPath: "id"
+  },
+  {
+    id: "orthodox-boundaries",
+    label: "正统边界",
+    detail: "OrthodoxBoundary",
+    recordType: "OrthodoxBoundaryRecord",
+    schema: "orthodox_boundary.schema.json",
+    file: "orthodox_boundaries.jsonl",
+    keyPath: "id"
+  },
+  {
+    id: "orthodox-periods",
+    label: "正统时期",
+    detail: "OrthodoxPeriod",
+    recordType: "OrthodoxPeriodRecord",
+    schema: "orthodox_period.schema.json",
+    file: "orthodox_periods.jsonl",
+    keyPath: "id"
+  }
+];
+
+const datasetByID = new Map(datasets.map((dataset) => [dataset.id, dataset]));
+
+function usage() {
+  return `
+Usage: Scripts/DataAdmin/server.mjs [options]
+
+Options:
+  --host <host>    Host to bind. Default: 127.0.0.1
+  --port <port>    Port to bind. Default: 5177
+  --help           Print this help.
+`;
+}
+
+function parseArguments(argv) {
+  const options = {
+    host: process.env.CHINESE_CALENDAR_DATA_ADMIN_HOST ?? "127.0.0.1",
+    port: Number(process.env.CHINESE_CALENDAR_DATA_ADMIN_PORT ?? 5177)
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const argument = argv[index];
+    switch (argument) {
+      case "--host":
+        options.host = requiredValue(argv, argument, ++index);
+        break;
+      case "--port": {
+        const value = Number(requiredValue(argv, argument, ++index));
+        if (!Number.isInteger(value) || value <= 0) {
+          throw new Error("--port must be a positive integer.");
+        }
+        options.port = value;
+        break;
+      }
+      case "--help":
+      case "-h":
+        console.log(usage().trim());
+        process.exit(0);
+      default:
+        throw new Error(`Unknown argument: ${argument}`);
+    }
+  }
+
+  return options;
+}
+
+function requiredValue(argv, argument, index) {
+  if (index >= argv.length) {
+    throw new Error(`Missing value after ${argument}.`);
+  }
+  return argv[index];
+}
+
+async function main() {
+  const options = parseArguments(process.argv.slice(2));
+  const server = http.createServer((request, response) => {
+    handleRequest(request, response).catch((error) => {
+      sendJSON(response, error.statusCode ?? 500, {
+        error: error.message ?? "Unexpected server error."
+      });
+    });
+  });
+
+  server.listen(options.port, options.host, () => {
+    console.log(`Chinese Calendar Data Admin running at http://${options.host}:${options.port}`);
+  });
+}
+
+async function handleRequest(request, response) {
+  const url = new URL(request.url ?? "/", "http://localhost");
+
+  if (url.pathname === "/api/meta" && request.method === "GET") {
+    return sendJSON(response, 200, await metaResponse());
+  }
+
+  if (url.pathname === "/api/records" && request.method === "GET") {
+    return sendJSON(response, 200, await recordsResponse(url.searchParams));
+  }
+
+  if (url.pathname === "/api/record" && request.method === "PUT") {
+    return sendJSON(response, 200, await updateRecordResponse(await readBody(request)));
+  }
+
+  if (url.pathname === "/api/diff" && request.method === "GET") {
+    return sendJSON(response, 200, await diffResponse(url.searchParams));
+  }
+
+  if (url.pathname === "/api/commands/validate" && request.method === "POST") {
+    return sendJSON(response, 200, await validateResponse());
+  }
+
+  if (url.pathname === "/api/commands/build-seed" && request.method === "POST") {
+    return sendJSON(response, 200, await buildSeedResponse());
+  }
+
+  return serveStatic(url.pathname, response);
+}
+
+async function metaResponse() {
+  const manifest = await readOptionalJSON(path.join(dataRoot, "manifest.json"));
+  const schemaDescriptions = await loadSchemaDescriptions();
+  const yearDirectories = await listCalendarYears();
+  const datasetMetadata = await Promise.all(datasets.map(async (dataset) => {
+    const filePath = dataset.yearScoped ? null : resolveDatasetFile(dataset, null);
+    return {
+      ...publicDatasetFields(dataset),
+      path: dataset.yearScoped ? "calendar_days/<year>/calendar_days.jsonl" : relativeToRoot(filePath),
+      recordCount: dataset.yearScoped ? manifest?.totalCalendarDays ?? null : await countLinesIfPresent(filePath),
+      schema: schemaDescriptions[dataset.id] ?? {},
+      selectedYearCount: null
+    };
+  }));
+
+  return {
+    repositoryRoot,
+    dataRoot: relativeToRoot(dataRoot),
+    manifest: manifestSummary(manifest),
+    calendarYears: yearDirectories,
+    datasets: datasetMetadata
+  };
+}
+
+async function loadSchemaDescriptions() {
+  const result = {};
+  for (const dataset of datasets) {
+    const schema = await readOptionalJSON(path.join(schemasRoot, dataset.schema));
+    if (!schema) {
+      result[dataset.id] = {};
+      continue;
+    }
+    result[dataset.id] = extractDescriptions(schema);
+  }
+  return result;
+}
+
+function extractDescriptions(schema) {
+  const descriptions = {};
+  collectDescriptions(schema, schema, "", descriptions);
+  return descriptions;
+}
+
+function collectDescriptions(schema, rootSchema, prefix, descriptions) {
+  const resolved = schema.$ref ? resolveSchemaReference(schema.$ref, rootSchema) : schema;
+  const description = schema.description ?? resolved.description;
+  if (description && prefix) {
+    descriptions[prefix] = description;
+  }
+
+  const properties = resolved.properties ?? {};
+  for (const [key, propertySchema] of Object.entries(properties)) {
+    const pathPrefix = prefix ? `${prefix}.${key}` : key;
+    collectDescriptions(propertySchema, rootSchema, pathPrefix, descriptions);
+  }
+}
+
+function resolveSchemaReference(reference, rootSchema) {
+  const prefix = "#/$defs/";
+  if (!reference.startsWith(prefix)) {
+    throw new Error(`Unsupported schema reference: ${reference}`);
+  }
+  const key = reference.slice(prefix.length);
+  const definition = rootSchema.$defs?.[key];
+  if (!definition) {
+    throw new Error(`Missing schema definition: ${reference}`);
+  }
+  return definition;
+}
+
+function publicDatasetFields(dataset) {
+  return {
+    id: dataset.id,
+    label: dataset.label,
+    detail: dataset.detail,
+    recordType: dataset.recordType,
+    yearScoped: Boolean(dataset.yearScoped),
+    keyPath: dataset.keyPath
+  };
+}
+
+function manifestSummary(manifest) {
+  if (!manifest) {
+    return null;
+  }
+  return {
+    generatedAt: manifest.generatedAt ?? null,
+    startYear: manifest.startYear ?? null,
+    endYear: manifest.endYear ?? null,
+    totalCalendarDays: manifest.totalCalendarDays ?? null,
+    totalChineseLunarYears: manifest.totalChineseLunarYears ?? null,
+    totalChineseLunarMonths: manifest.totalChineseLunarMonths ?? null,
+    totalDynasties: manifest.dynastyArtifact?.totalDynasties ?? null,
+    sourceUpstreamCommit: manifest.sourceUpstreamCommit ?? null
+  };
+}
+
+async function recordsResponse(searchParams) {
+  const dataset = requiredDataset(searchParams.get("dataset"));
+  const filePath = resolveDatasetFile(dataset, searchParams.get("year"));
+  const limit = integerParam(searchParams, "limit", 200, { min: 1, max: 1000 });
+  const offset = integerParam(searchParams, "offset", 0, { min: 0, max: Number.MAX_SAFE_INTEGER });
+  const query = (searchParams.get("query") ?? "").trim().toLowerCase();
+
+  const records = [];
+  let matchedCount = 0;
+  let lineNumber = 0;
+  let invalidCount = 0;
+
+  for await (const line of readLines(filePath)) {
+    lineNumber += 1;
+    if (line.length === 0) {
+      continue;
+    }
+
+    let record = null;
+    let parseError = null;
+    try {
+      record = JSON.parse(line);
+    } catch (error) {
+      parseError = error.message;
+      invalidCount += 1;
+    }
+
+    const searchable = `${line} ${record ? summarizeRecord(dataset.id, record) : ""}`.toLowerCase();
+    if (query && !searchable.includes(query)) {
+      continue;
+    }
+
+    matchedCount += 1;
+    if (matchedCount <= offset || records.length >= limit) {
+      continue;
+    }
+
+    records.push({
+      lineNumber,
+      key: record ? valueAtPath(record, dataset.keyPath) : null,
+      summary: record ? summarizeRecord(dataset.id, record) : "Invalid JSON",
+      readable: record ? readableRecord(dataset.id, record) : [],
+      raw: line,
+      record,
+      parseError
+    });
+  }
+
+  return {
+    dataset: publicDatasetFields(dataset),
+    path: relativeToRoot(filePath),
+    fileRecordCount: lineNumber,
+    matchedCount,
+    invalidCount,
+    offset,
+    limit,
+    records
+  };
+}
+
+async function updateRecordResponse(body) {
+  const payload = parseJSON(body, "Request body");
+  const dataset = requiredDataset(payload.dataset);
+  const filePath = resolveDatasetFile(dataset, payload.year ?? null);
+  const lineNumber = payload.lineNumber;
+  if (!Number.isInteger(lineNumber) || lineNumber < 1) {
+    throw httpError(400, "lineNumber must be a positive integer.");
+  }
+
+  const nextRecord = payload.raw !== undefined
+    ? parseJSON(String(payload.raw), "JSONL line")
+    : payload.record;
+
+  if (!nextRecord || typeof nextRecord !== "object" || Array.isArray(nextRecord)) {
+    throw httpError(400, "Record must be a JSON object.");
+  }
+
+  const nextLine = JSON.stringify(nextRecord);
+  await replaceLine(filePath, lineNumber, nextLine);
+
+  return {
+    ok: true,
+    dataset: publicDatasetFields(dataset),
+    path: relativeToRoot(filePath),
+    lineNumber,
+    raw: nextLine,
+    record: nextRecord,
+    summary: summarizeRecord(dataset.id, nextRecord),
+    readable: readableRecord(dataset.id, nextRecord)
+  };
+}
+
+async function diffResponse(searchParams) {
+  const dataset = requiredDataset(searchParams.get("dataset"));
+  const filePath = resolveDatasetFile(dataset, searchParams.get("year"));
+  const result = await runCommand("git", ["diff", "--", relativeToRoot(filePath)]);
+  return {
+    ok: result.status === 0,
+    path: relativeToRoot(filePath),
+    diff: result.output,
+    status: result.status
+  };
+}
+
+async function validateResponse() {
+  const steps = [
+    {
+      label: "Generated schema artifacts",
+      command: "Scripts/DataSchemas/generate_schema_artifacts.swift",
+      args: ["--check"]
+    },
+    {
+      label: "JSON schema",
+      command: "Scripts/DataSchemas/validate_swiftdata_import.swift",
+      args: []
+    },
+    {
+      label: "Calendar import invariants",
+      command: "Scripts/ImportChineseCalendar/generate_swiftdata_import.swift",
+      args: ["--validate-only"]
+    },
+    {
+      label: "Dynasty import invariants",
+      command: "Scripts/ImportChineseCalendar/generate_dynasty_periods.swift",
+      args: ["--validate-only"]
+    }
+  ];
+  return runSteps(steps);
+}
+
+async function buildSeedResponse() {
+  return runSteps([
+    {
+      label: "SwiftData SQLite seed store",
+      command: "Scripts/BuildChineseCalendarSeedStore/generate_seed_store_if_needed.sh",
+      args: []
+    }
+  ]);
+}
+
+async function runSteps(steps) {
+  const results = [];
+  for (const step of steps) {
+    const result = await runCommand(step.command, step.args);
+    results.push({ ...step, ...result });
+    if (result.status !== 0) {
+      return { ok: false, results };
+    }
+  }
+  return { ok: true, results };
+}
+
+async function runCommand(command, args) {
+  return new Promise((resolve) => {
+    const executable = command.includes("/") ? path.join(repositoryRoot, command) : command;
+    const child = spawn(executable, args, {
+      cwd: repositoryRoot,
+      env: command.endsWith("generate_seed_store_if_needed.sh")
+        ? withoutKeys(process.env, ["SDKROOT", "TOOLCHAINS"])
+        : process.env
+    });
+    let output = "";
+    child.stdout.on("data", (chunk) => { output += chunk; });
+    child.stderr.on("data", (chunk) => { output += chunk; });
+    child.on("error", (error) => {
+      resolve({ status: 1, output: error.message });
+    });
+    child.on("close", (status) => {
+      resolve({ status, output: output.trimEnd() });
+    });
+  });
+}
+
+function withoutKeys(env, keys) {
+  const next = { ...env };
+  for (const key of keys) {
+    delete next[key];
+  }
+  return next;
+}
+
+async function replaceLine(filePath, lineNumber, nextLine) {
+  const text = await readFile(filePath, "utf8");
+  const lines = text.endsWith("\n") ? text.slice(0, -1).split("\n") : text.split("\n");
+  if (lineNumber > lines.length) {
+    throw httpError(400, `Line ${lineNumber} does not exist in ${relativeToRoot(filePath)}.`);
+  }
+
+  lines[lineNumber - 1] = nextLine;
+  const output = `${lines.join("\n")}\n`;
+  const temporaryPath = `${filePath}.tmp-${process.pid}-${Date.now()}`;
+  await writeFile(temporaryPath, output, "utf8");
+  await rename(temporaryPath, filePath);
+}
+
+async function* readLines(filePath) {
+  const input = createReadStream(filePath, { encoding: "utf8" });
+  const reader = createInterface({ input, crlfDelay: Infinity });
+  for await (const line of reader) {
+    yield line;
+  }
+}
+
+async function listCalendarYears() {
+  const calendarRoot = path.join(dataRoot, "calendar_days");
+  try {
+    const entries = await readdir(calendarRoot, { withFileTypes: true });
+    return entries
+      .filter((entry) => entry.isDirectory() && /^-?\d+$/.test(entry.name))
+      .map((entry) => Number(entry.name))
+      .sort((lhs, rhs) => lhs - rhs);
+  } catch {
+    return [];
+  }
+}
+
+async function countLinesIfPresent(filePath) {
+  if (!filePath) {
+    return null;
+  }
+  try {
+    let count = 0;
+    for await (const line of readLines(filePath)) {
+      if (line.length > 0) {
+        count += 1;
+      }
+    }
+    return count;
+  } catch {
+    return null;
+  }
+}
+
+function requiredDataset(id) {
+  const dataset = datasetByID.get(id ?? "");
+  if (!dataset) {
+    throw httpError(400, `Unknown dataset: ${id ?? ""}.`);
+  }
+  return dataset;
+}
+
+function resolveDatasetFile(dataset, yearValue) {
+  const relativePath = dataset.yearScoped
+    ? `calendar_days/${requiredYear(yearValue)}/calendar_days.jsonl`
+    : dataset.file;
+  const filePath = path.resolve(dataRoot, relativePath);
+  const relative = path.relative(dataRoot, filePath);
+  if (relative.startsWith("..") || path.isAbsolute(relative)) {
+    throw httpError(400, "Resolved path escapes the data root.");
+  }
+  return filePath;
+}
+
+function requiredYear(value) {
+  const year = Number(value);
+  if (!Number.isInteger(year)) {
+    throw httpError(400, "A civil year is required for calendar day records.");
+  }
+  return String(year);
+}
+
+function integerParam(searchParams, key, defaultValue, bounds) {
+  const rawValue = searchParams.get(key);
+  if (rawValue === null || rawValue === "") {
+    return defaultValue;
+  }
+  const value = Number(rawValue);
+  if (!Number.isInteger(value) || value < bounds.min || value > bounds.max) {
+    throw httpError(400, `${key} must be an integer between ${bounds.min} and ${bounds.max}.`);
+  }
+  return value;
+}
+
+function summarizeRecord(datasetID, record) {
+  switch (datasetID) {
+    case "lunar-years":
+      return `农历年 ${record.lunarYearNumber} · ${stemBranch(record.yearStemIndex, record.yearBranchIndex)}`;
+    case "lunar-months":
+      return `农历 ${record.lunarYearNumber} 年 ${lunarMonthName(record)} · ${record.dayCount} 日 · ${stemBranch(record.monthStemIndex, record.monthBranchIndex)}`;
+    case "calendar-days":
+      return `${record.civilDate?.year}-${pad(record.civilDate?.month)}-${pad(record.civilDate?.dayOfMonth)} -> 月 ${record.chineseLunarDay?.lunarMonthIndex} 日 ${record.chineseLunarDay?.dayNumberInMonth} · ${stemBranch(record.chineseLunarDay?.dayStemIndex, record.chineseLunarDay?.dayBranchIndex)}`;
+    case "dynasties":
+      return `${record.name}${record.shortName ? ` (${record.shortName})` : ""}`;
+    case "date-expressions":
+      return `${record.id}: ${record.sourceText}`;
+    case "orthodox-traditions":
+      return record.name;
+    case "orthodox-boundaries":
+      return `${record.id}: ${record.dateExpressionID}`;
+    case "orthodox-periods":
+      return `${record.sequenceIndex}. ${record.segmentName} / ${record.dynastyID}`;
+    default:
+      return JSON.stringify(record);
+  }
+}
+
+function readableRecord(datasetID, record) {
+  switch (datasetID) {
+    case "lunar-years":
+      return [
+        item("农历年编号", record.lunarYearNumber, "lunarYearNumber"),
+        item("年天干", stemName(record.yearStemIndex), "yearStemIndex"),
+        item("年地支", branchName(record.yearBranchIndex), "yearBranchIndex"),
+        item("年干支", stemBranch(record.yearStemIndex, record.yearBranchIndex)),
+        item("生肖", zodiacName(record.yearBranchIndex))
+      ];
+    case "lunar-months":
+      return [
+        item("农历月索引", record.lunarMonthIndex, "lunarMonthIndex"),
+        item("所属农历年", record.lunarYearNumber, "lunarYearNumber"),
+        item("月名", lunarMonthName(record), "monthNumberInYear"),
+        item("是否闰月", record.isLeapMonth ? "是" : "否", "isLeapMonth"),
+        item("置闰显示", intercalaryStyleName(record.intercalaryMonthNameStyle), "intercalaryMonthNameStyle"),
+        item("本月天数", `${record.dayCount} 天（${record.dayCount === 29 ? "小月" : "大月"}）`, "dayCount"),
+        item("月天干", stemName(record.monthStemIndex), "monthStemIndex"),
+        item("月地支", branchName(record.monthBranchIndex), "monthBranchIndex"),
+        item("月干支", stemBranch(record.monthStemIndex, record.monthBranchIndex))
+      ];
+    case "calendar-days":
+      return [
+        item("绝对日索引", record.calendarDay?.dayIndex, "calendarDay.dayIndex"),
+        item("Julian Day Number", record.calendarDay?.julianDayNumber, "calendarDay.julianDayNumber"),
+        item("民用日期", civilDateLabel(record.civilDate), "civilDate"),
+        item("历法", civilCalendarStyleName(record.civilDate?.calendarStyle), "civilDate.calendarStyle"),
+        item("农历月索引", record.chineseLunarDay?.lunarMonthIndex, "chineseLunarDay.lunarMonthIndex"),
+        item("农历月内日序", record.chineseLunarDay?.dayNumberInMonth, "chineseLunarDay.dayNumberInMonth"),
+        item("日天干", stemName(record.chineseLunarDay?.dayStemIndex), "chineseLunarDay.dayStemIndex"),
+        item("日地支", branchName(record.chineseLunarDay?.dayBranchIndex), "chineseLunarDay.dayBranchIndex"),
+        item("日干支", stemBranch(record.chineseLunarDay?.dayStemIndex, record.chineseLunarDay?.dayBranchIndex)),
+        item("日生肖", zodiacName(record.chineseLunarDay?.dayBranchIndex))
+      ];
+    case "dynasties":
+      return [
+        item("标识符", record.id, "id"),
+        item("名称", record.name, "name"),
+        item("简称", record.shortName ?? "无", "shortName"),
+        item("开始日期 ID", record.claimedStartDateID, "claimedStartDateID"),
+        item("结束日期 ID", record.claimedEndDateID, "claimedEndDateID"),
+        item("说明", record.note ?? "无", "note")
+      ];
+    case "date-expressions":
+      return [
+        item("标识符", record.id, "id"),
+        item("日期精度", precisionName(record.precision), "precision"),
+        item("日期索引", record.index ?? "无", "index"),
+        item("来源原文", record.sourceText, "sourceText"),
+        item("说明", record.note ?? "无", "note")
+      ];
+    case "orthodox-traditions":
+      return [item("标识符", record.id, "id"), item("名称", record.name, "name"), item("说明", record.note ?? "无", "note")];
+    case "orthodox-boundaries":
+      return [
+        item("标识符", record.id, "id"),
+        item("正统叙事 ID", record.traditionID, "traditionID"),
+        item("日期表达 ID", record.dateExpressionID, "dateExpressionID"),
+        item("说明", record.note ?? "无", "note")
+      ];
+    case "orthodox-periods":
+      return [
+        item("标识符", record.id, "id"),
+        item("正统叙事 ID", record.traditionID, "traditionID"),
+        item("朝代 ID", record.dynastyID, "dynastyID"),
+        item("开始边界 ID", record.startBoundaryID, "startBoundaryID"),
+        item("结束边界 ID", record.endBoundaryID, "endBoundaryID"),
+        item("全局顺序", record.sequenceIndex, "sequenceIndex"),
+        item("分段顺序", record.segmentIndex, "segmentIndex"),
+        item("分段名称", record.segmentName, "segmentName"),
+        item("说明", record.note ?? "无", "note")
+      ];
+    default:
+      return [];
+  }
+}
+
+function item(label, value, pathName = null) {
+  return { label, value: String(value ?? "无"), path: pathName };
+}
+
+function stemName(index) {
+  return indexedName(heavenlyStems, index, "天干");
+}
+
+function branchName(index) {
+  return indexedName(earthlyBranches, index, "地支");
+}
+
+function zodiacName(branchIndex) {
+  if (!Number.isInteger(branchIndex) || branchIndex < 0 || branchIndex >= zodiacAnimals.length) {
+    return "未知";
+  }
+  return `${zodiacAnimals[branchIndex]}（${branchIndex}）`;
+}
+
+function indexedName(values, index, label) {
+  if (!Number.isInteger(index) || index < 0 || index >= values.length) {
+    return `未知${label}`;
+  }
+  return `${values[index]}（${index}）`;
+}
+
+function stemBranch(stemIndex, branchIndex) {
+  if (!Number.isInteger(stemIndex) || !Number.isInteger(branchIndex)) {
+    return "未知干支";
+  }
+  return `${heavenlyStems[stemIndex] ?? "?"}${earthlyBranches[branchIndex] ?? "?"}（${stemIndex}/${branchIndex}）`;
+}
+
+function lunarMonthName(record) {
+  const prefix = record.isLeapMonth
+    ? record.intercalaryMonthNameStyle === "post" ? "后" : "闰"
+    : "";
+  return `${prefix}${record.monthNumberInYear} 月`;
+}
+
+function intercalaryStyleName(style) {
+  switch (style) {
+    case "leap":
+      return "闰月（闰 X 月）";
+    case "post":
+      return "后月（后 X 月）";
+    default:
+      return String(style ?? "未知");
+  }
+}
+
+function civilDateLabel(civilDate) {
+  if (!civilDate) {
+    return "未知";
+  }
+  return `${civilDate.year}-${pad(civilDate.month)}-${pad(civilDate.dayOfMonth)}`;
+}
+
+function civilCalendarStyleName(style) {
+  switch (style) {
+    case "gregorian":
+      return "格里历（gregorian）";
+    case "julian":
+      return "儒略历（julian）";
+    default:
+      return String(style ?? "未知");
+  }
+}
+
+function precisionName(precision) {
+  switch (precision) {
+    case "year":
+      return "年精度";
+    case "month":
+      return "月精度";
+    case "day":
+      return "日精度";
+    case "range":
+      return "范围";
+    case "unknown":
+      return "未知";
+    default:
+      return String(precision ?? "未知");
+  }
+}
+
+function pad(value) {
+  return String(value ?? "?").padStart(2, "0");
+}
+
+function valueAtPath(record, keyPath) {
+  return keyPath.split(".").reduce((value, key) => value?.[key], record) ?? null;
+}
+
+async function serveStatic(pathname, response) {
+  const normalizedPath = pathname === "/" ? "/index.html" : pathname;
+  const filePath = path.resolve(publicRoot, `.${decodeURIComponent(normalizedPath)}`);
+  const relative = path.relative(publicRoot, filePath);
+  if (relative.startsWith("..") || path.isAbsolute(relative)) {
+    throw httpError(404, "Not found.");
+  }
+
+  try {
+    const fileStat = await stat(filePath);
+    if (!fileStat.isFile()) {
+      throw httpError(404, "Not found.");
+    }
+  } catch {
+    throw httpError(404, "Not found.");
+  }
+
+  response.writeHead(200, {
+    "Content-Type": contentType(filePath),
+    "Cache-Control": "no-store"
+  });
+  createReadStream(filePath).pipe(response);
+}
+
+function contentType(filePath) {
+  switch (path.extname(filePath)) {
+    case ".html":
+      return "text/html; charset=utf-8";
+    case ".css":
+      return "text/css; charset=utf-8";
+    case ".js":
+      return "text/javascript; charset=utf-8";
+    case ".json":
+      return "application/json; charset=utf-8";
+    default:
+      return "application/octet-stream";
+  }
+}
+
+function parseJSON(text, label) {
+  try {
+    return JSON.parse(text);
+  } catch (error) {
+    throw httpError(400, `${label} is not valid JSON. ${error.message}`);
+  }
+}
+
+async function readOptionalJSON(filePath) {
+  try {
+    return JSON.parse(await readFile(filePath, "utf8"));
+  } catch {
+    return null;
+  }
+}
+
+async function readBody(request) {
+  const chunks = [];
+  for await (const chunk of request) {
+    chunks.push(chunk);
+  }
+  return Buffer.concat(chunks).toString("utf8");
+}
+
+function sendJSON(response, statusCode, value) {
+  response.writeHead(statusCode, { "Content-Type": "application/json; charset=utf-8" });
+  response.end(`${JSON.stringify(value)}\n`);
+}
+
+function relativeToRoot(filePath) {
+  return path.relative(repositoryRoot, filePath);
+}
+
+function httpError(statusCode, message) {
+  const error = new Error(message);
+  error.statusCode = statusCode;
+  return error;
+}
+
+main().catch((error) => {
+  console.error(error.message);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add a local no-dependency DataAdmin web app for browsing, searching, editing, diffing, validating, and building JSONL-backed SwiftData seed data
- add Chinese field descriptions to JSON schemas so raw stem/branch/month fields are easier to understand
- show readable previews in the DataAdmin UI, including heavenly stems, earthly branches, zodiac, lunar month sizes, and dynasty/orthodox-period fields
- make seed-store rebuild detection watch all SwiftData import JSONL files, including dynasty and orthodox data

## Validation
- jq empty Data/Schemas/*.schema.json
- Scripts/DataSchemas/generate_schema_artifacts.swift --check
- node --check Scripts/DataAdmin/server.mjs
- node --check Scripts/DataAdmin/public/app.js
- bash -n Scripts/BuildChineseCalendarSeedStore/generate_seed_store_if_needed.sh
- swift test --package-path Sources