### PR TITLE
Update signing team and add Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,49 @@
+.DEFAULT_GOAL := help
+
+.PHONY: help xcodeproj buildserver setup test format format-check lint ci build-apps seed-store validate-data-schemas
+
+help:
+	@echo "Common commands:"
+	@echo "  make xcodeproj             Generate ChineseCalendar.xcodeproj"
+	@echo "  make buildserver           Generate VS Code buildServer.json"
+	@echo "  make setup                 Generate Xcode project and build server config"
+	@echo "  make test                  Run Swift package tests"
+	@echo "  make format                Format Swift sources"
+	@echo "  make format-check          Check Swift formatting"
+	@echo "  make lint                  Run SwiftLint"
+	@echo "  make ci                    Run local CI checks"
+	@echo "  make build-apps            Build iOS and macOS app targets"
+	@echo "  make seed-store            Rebuild SwiftData seed store if needed"
+	@echo "  make validate-data-schemas Validate generated data schema artifacts"
+
+xcodeproj:
+	./Scripts/generate_xcodeproj.sh
+
+buildserver:
+	./Scripts/generate_buildserver_config.sh
+
+setup: xcodeproj buildserver
+
+test:
+	./Scripts/test.sh
+
+format:
+	./Scripts/format.sh
+
+format-check:
+	./Scripts/format.sh --check
+
+lint:
+	./Scripts/lint.sh
+
+ci:
+	./Scripts/ci.sh
+
+build-apps:
+	./Scripts/build_apps.sh
+
+seed-store:
+	./Scripts/BuildChineseCalendarSeedStore/generate_seed_store_if_needed.sh
+
+validate-data-schemas:
+	./Scripts/validate_data_schemas.sh

--- a/project.yml
+++ b/project.yml
@@ -60,7 +60,7 @@ targets:
         SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD: NO
         SWIFT_VERSION: 6.0
         CODE_SIGN_STYLE: Automatic
-        DEVELOPMENT_TEAM: 28TY995J85
+        DEVELOPMENT_TEAM: F29WG8477A
         CODE_SIGN_ENTITLEMENTS: Apps/iOSApp/ChineseCalendar-iOS.entitlements
         MARKETING_VERSION: 1.0
         CURRENT_PROJECT_VERSION: 1
@@ -113,7 +113,7 @@ targets:
         INFOPLIST_KEY_LSApplicationCategoryType: public.app-category.reference
         SWIFT_VERSION: 6.0
         CODE_SIGN_STYLE: Automatic
-        DEVELOPMENT_TEAM: 28TY995J85
+        DEVELOPMENT_TEAM: F29WG8477A
         CODE_SIGN_ENTITLEMENTS: Apps/macOSApp/ChineseCalendar-macOS.entitlements
         MARKETING_VERSION: 1.0
         CURRENT_PROJECT_VERSION: 1


### PR DESCRIPTION
## Summary
- update generated app targets to use signing team F29WG8477A
- add a simple Makefile with common project commands

## Verification
- make
- make xcodeproj