### PR TITLE
Improve full data download progress and settings

### DIFF
--- a/Apps/macOSApp/Sources/ChineseCalendarMacApp.swift
+++ b/Apps/macOSApp/Sources/ChineseCalendarMacApp.swift
@@ -4,14 +4,27 @@ import SwiftUI
 
 @main
 struct ChineseCalendarMacApp: App {
+    @State private var storeCoordinator = ChineseCalendarStoreCoordinator()
+
     init() {
         ChineseCalendarLog.app.notice("Launching macOS app")
     }
 
     var body: some Scene {
         WindowGroup {
-            ChineseCalendarRootView()
+            ChineseCalendarRootView(coordinator: storeCoordinator)
                 .frame(minWidth: 960, minHeight: 640)
+        }
+
+        Window("完整数据下载进度", id: FullStoreDownloadProgressWindow.sceneID) {
+            FullStoreDownloadProgressWindow(coordinator: storeCoordinator)
+        }
+        .defaultSize(width: 420, height: 220)
+
+        Settings {
+            CalendarSettingsView(coordinator: storeCoordinator)
+                .scenePadding()
+                .frame(width: 420)
         }
     }
 }

--- a/Sources/ChineseCalendarPersistence/SeededModelContainer.swift
+++ b/Sources/ChineseCalendarPersistence/SeededModelContainer.swift
@@ -305,6 +305,60 @@ public enum ChineseCalendarModelContainerFactory {
     }
 }
 
+public extension ChineseCalendarModelContainerFactory {
+    @discardableResult
+    static func clearDownloadedSeedStore(
+        bundle: Bundle = .main,
+        appGroupIdentifier: String = ChineseCalendarAppConfiguration.appGroupIdentifier,
+        fileManager: FileManager = .default
+    ) throws -> URL {
+        let storeDirectory = try sharedStoreDirectory(
+            appGroupIdentifier: appGroupIdentifier,
+            fileManager: fileManager
+        )
+
+        guard let seedDirectory = seedStoreResourceURL(in: bundle) else {
+            ChineseCalendarLog.persistence.error("Missing bundled seed store resource")
+            throw ChineseCalendarStoreError.missingSeedResource(
+                "\(ChineseCalendarSeedStore.resourceBundleName).\(ChineseCalendarSeedStore.resourceBundleExtension)"
+            )
+        }
+
+        ChineseCalendarLog.persistence.notice("Clearing downloaded seed store and restoring bundled base store")
+
+        try ChineseCalendarSeedStoreFiles.removeStoreFiles(
+            in: storeDirectory,
+            fileManager: fileManager
+        )
+
+        let installedManifestURL = storeDirectory.appendingPathComponent(ChineseCalendarSeedStore.manifestFileName)
+        if fileManager.fileExists(atPath: installedManifestURL.path) {
+            try fileManager.removeItem(at: installedManifestURL)
+        }
+
+        try ChineseCalendarSeedStoreFiles.copyStoreFiles(
+            from: seedDirectory,
+            to: storeDirectory,
+            fileManager: fileManager
+        )
+        try copyManifestIfPresent(
+            from: seedDirectory,
+            to: storeDirectory,
+            fileManager: fileManager
+        )
+
+        let downloadsDirectory = try downloadsDirectory(
+            appGroupIdentifier: appGroupIdentifier,
+            fileManager: fileManager
+        )
+        if fileManager.fileExists(atPath: downloadsDirectory.path) {
+            try fileManager.removeItem(at: downloadsDirectory)
+        }
+
+        return storeDirectory.appendingPathComponent(ChineseCalendarSeedStore.storeFileName)
+    }
+}
+
 enum ChineseCalendarSeedStoreFiles {
     static func removeStoreFiles(
         in directoryURL: URL,

--- a/Sources/ChineseCalendarUI/CalendarSettingsView.swift
+++ b/Sources/ChineseCalendarUI/CalendarSettingsView.swift
@@ -1,0 +1,155 @@
+import ChineseCalendarPersistence
+import SwiftUI
+
+public struct CalendarSettingsView: View {
+    private let coordinator: ChineseCalendarStoreCoordinator
+
+    @Environment(\.dismiss) private var dismiss
+    @State private var isConfirmingClear = false
+    @State private var resultMessage: SettingsResultMessage?
+
+    public init(coordinator: ChineseCalendarStoreCoordinator) {
+        self.coordinator = coordinator
+    }
+
+    public var body: some View {
+        Form {
+            Section("数据") {
+                VStack(alignment: .leading, spacing: 6) {
+                    Label(dataStatusTitle, systemImage: dataStatusSystemImage)
+                        .font(.headline)
+                    Text(dataStatusDetail)
+                        .font(.callout)
+                        .foregroundStyle(.secondary)
+                }
+                .padding(.vertical, 4)
+
+                Button(role: .destructive) {
+                    isConfirmingClear = true
+                } label: {
+                    if coordinator.isClearingDownloadedData {
+                        Label {
+                            Text("正在清空")
+                        } icon: {
+                            ProgressView()
+                        }
+                    } else {
+                        Label("清空已下载数据", systemImage: "trash")
+                    }
+                }
+                .disabled(coordinator.isClearingDownloadedData)
+            }
+        }
+        #if os(iOS)
+        .navigationTitle("设置")
+        .toolbar {
+            ToolbarItem(placement: .confirmationAction) {
+                Button("完成") {
+                    dismiss()
+                }
+            }
+        }
+        #endif
+        .confirmationDialog(
+            "清空已下载数据？",
+            isPresented: $isConfirmingClear,
+            titleVisibility: .visible
+        ) {
+            Button("清空已下载数据", role: .destructive) {
+                clearDownloadedData()
+            }
+        } message: {
+            Text("这会取消正在进行的完整数据下载，删除下载缓存，并恢复到内置基础日历数据。")
+        }
+        .alert(resultMessage?.title ?? "", isPresented: resultMessageIsPresented, presenting: resultMessage) { _ in
+            Button("好", role: .cancel) {}
+        } message: { resultMessage in
+            Text(resultMessage.message)
+        }
+    }
+
+    private var resultMessageIsPresented: Binding<Bool> {
+        Binding(
+            get: { resultMessage != nil },
+            set: { isPresented in
+                if !isPresented {
+                    resultMessage = nil
+                }
+            }
+        )
+    }
+
+    private var dataStatusTitle: String {
+        if coordinator.fullStoreDownloadProgress != nil {
+            return "完整数据下载中"
+        }
+
+        switch coordinator.state {
+        case .ready(_, .full, _):
+            return "已安装完整日期数据"
+        case .ready:
+            return "正在使用内置基础数据"
+        case .starting:
+            return "正在准备日历数据"
+        case .failed:
+            return "日历数据需要恢复"
+        }
+    }
+
+    private var dataStatusDetail: String {
+        if coordinator.fullStoreDownloadProgress != nil {
+            return "清空会取消当前下载，并删除已经保存的临时文件。"
+        }
+
+        switch coordinator.state {
+        case .ready(_, .full, _):
+            return "清空后会回到基础数据，日级记录需要重新下载完整数据后才能浏览。"
+        case .ready:
+            return "没有已安装的完整日期数据；仍可清理未完成的下载缓存。"
+        case .starting:
+            return "日历数据准备完成后可以清理下载缓存。"
+        case .failed:
+            return "可以尝试清空下载数据并恢复内置基础数据。"
+        }
+    }
+
+    private var dataStatusSystemImage: String {
+        if coordinator.fullStoreDownloadProgress != nil {
+            return "arrow.down.circle"
+        }
+
+        switch coordinator.state {
+        case .ready(_, .full, _):
+            return "externaldrive.fill"
+        case .ready:
+            return "externaldrive"
+        case .starting:
+            return "hourglass"
+        case .failed:
+            return "externaldrive.badge.exclamationmark"
+        }
+    }
+
+    private func clearDownloadedData() {
+        Task {
+            do {
+                try await coordinator.clearDownloadedData()
+                resultMessage = SettingsResultMessage(
+                    title: "已清空",
+                    message: "已删除下载数据，并恢复到内置基础日历数据。"
+                )
+            } catch {
+                resultMessage = SettingsResultMessage(
+                    title: "清空失败",
+                    message: error.localizedDescription
+                )
+            }
+        }
+    }
+}
+
+private struct SettingsResultMessage: Identifiable {
+    let id = UUID()
+    let title: String
+    let message: String
+}

--- a/Sources/ChineseCalendarUI/ChineseCalendarRootView.swift
+++ b/Sources/ChineseCalendarUI/ChineseCalendarRootView.swift
@@ -1,170 +1,101 @@
-import ChineseCalendarLogging
 import ChineseCalendarPersistence
 import SwiftData
 import SwiftUI
 
 @MainActor
 public struct ChineseCalendarRootView: View {
-    @State private var state: CalendarStoreBootstrapState = .starting
-    @State private var downloadErrorMessage: String?
+    @Environment(\.openWindow) private var openWindow
+    @State private var coordinator: ChineseCalendarStoreCoordinator
+    @State private var isSettingsPresented = false
 
-    private let fullStoreConfiguration: FullSeedStoreConfig?
+    public init(coordinator: ChineseCalendarStoreCoordinator) {
+        _coordinator = State(initialValue: coordinator)
+    }
 
     public init(
         fullStoreConfiguration: FullSeedStoreConfig? = .fromBundle()
     ) {
-        self.fullStoreConfiguration = fullStoreConfiguration
+        _coordinator = State(
+            initialValue: ChineseCalendarStoreCoordinator(fullStoreConfiguration: fullStoreConfiguration)
+        )
     }
 
     public var body: some View {
         Group {
-            switch state {
+            switch coordinator.state {
             case .starting:
                 CalendarStoreProgressView(title: "正在准备日历数据", progress: nil)
             case let .ready(container, contentLevel, identityToken):
                 CalendarHomeView()
                     .environment(\.calendarStoreContentLevel, contentLevel)
                     .modelContainer(container)
-                    .id(storeIdentity(contentLevel: contentLevel, identityToken: identityToken))
+                    .id(coordinator.storeIdentity(contentLevel: contentLevel, identityToken: identityToken))
                     .safeAreaInset(edge: .bottom) {
-                        if canDownloadFullStore(contentLevel: contentLevel) {
-                            FullStoreDownloadBanner(action: startFullStoreDownload)
-                        }
+                        bottomStatusBar(contentLevel: contentLevel)
                     }
-            case let .downloading(progress):
-                CalendarStoreProgressView(title: "正在下载完整日历数据", progress: progress)
-            case .validating:
-                CalendarStoreProgressView(title: "正在校验完整日历数据", progress: nil)
-            case .installing:
-                CalendarStoreProgressView(title: "正在安装完整日历数据", progress: nil)
             case let .failed(message):
-                CalendarStoreFailureView(message: message, retry: prepareStore)
+                CalendarStoreFailureView(message: message, retry: coordinator.prepareStore)
+            }
+        }
+        .toolbar {
+            #if os(iOS)
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button("设置", systemImage: "gearshape") {
+                        isSettingsPresented = true
+                    }
+                }
+            #endif
+        }
+        .sheet(isPresented: $isSettingsPresented) {
+            NavigationStack {
+                CalendarSettingsView(coordinator: coordinator)
             }
         }
         .task {
-            await prepareStoreIfNeeded()
+            await coordinator.prepareStoreIfNeeded()
         }
         .alert("完整数据下载失败", isPresented: downloadErrorIsPresented) {
             Button("好", role: .cancel) {}
         } message: {
-            Text(downloadErrorMessage ?? "请稍后再试。")
+            Text(coordinator.downloadErrorMessage ?? "请稍后再试。")
         }
     }
 
     private var downloadErrorIsPresented: Binding<Bool> {
         Binding(
-            get: { downloadErrorMessage != nil },
+            get: { coordinator.downloadErrorMessage != nil },
             set: { isPresented in
                 if !isPresented {
-                    downloadErrorMessage = nil
+                    coordinator.dismissDownloadError()
                 }
             }
         )
     }
 
-    private func prepareStoreIfNeeded() async {
-        guard case .starting = state else {
-            return
-        }
-
-        prepareStore()
-    }
-
-    private func prepareStore() {
-        do {
-            let container = try ChineseCalendarModelContainerFactory.makeSharedContainer()
-            let contentLevel = try ChineseCalendarModelContainerFactory.installedStoreContentLevel() ?? .base
-            let identityToken = try ChineseCalendarModelContainerFactory.installedStoreIdentityToken()
-            state = .ready(container: container, contentLevel: contentLevel, identityToken: identityToken)
-        } catch {
-            ChineseCalendarLog.persistence.error("Failed to prepare SwiftData store: \(error.localizedDescription)")
-            state = .failed(message: error.localizedDescription)
+    @ViewBuilder
+    private func bottomStatusBar(contentLevel: ChineseCalendarSeedStoreContentLevel) -> some View {
+        if let progress = coordinator.fullStoreDownloadProgress {
+            #if os(iOS)
+                FullStoreDownloadBottomProgressView(progress: progress)
+            #else
+                FullStoreDownloadMacStatusBar(progress: progress, openProgressWindow: openDownloadProgressWindow)
+            #endif
+        } else if coordinator.canDownloadFullStore(contentLevel: contentLevel) {
+            FullStoreDownloadBanner(action: startFullStoreDownload)
         }
     }
 
     private func startFullStoreDownload() {
-        guard let fullStoreConfiguration else {
-            return
-        }
-
-        downloadErrorMessage = nil
-        state = .downloading(progress: nil)
-
-        Task {
-            await downloadAndInstallFullStore(configuration: fullStoreConfiguration)
+        if coordinator.startFullStoreDownload() {
+            openDownloadProgressWindow()
         }
     }
 
-    private func downloadAndInstallFullStore(
-        configuration: FullSeedStoreConfig
-    ) async {
-        let installer = ChineseCalendarFullSeedStoreInstaller(configuration: configuration)
-
-        do {
-            for try await event in await installer.installEvents() {
-                switch event {
-                case let .downloading(progress):
-                    state = .downloading(progress: progress)
-                case .validating:
-                    state = .validating
-                case .installing:
-                    state = .installing
-                case let .installed(result):
-                    let container = try ChineseCalendarModelContainerFactory.makeContainer(
-                        at: result.storeURL,
-                        allowsSave: false
-                    )
-                    state = .ready(
-                        container: container,
-                        contentLevel: .full,
-                        identityToken: result.manifest.datasetVersion
-                    )
-                }
-            }
-        } catch {
-            ChineseCalendarLog.persistence
-                .error("Failed to install full SwiftData store: \(error.localizedDescription)")
-            showDownloadErrorIfStoreRecovers(error.localizedDescription)
-        }
+    private func openDownloadProgressWindow() {
+        #if os(macOS)
+            openWindow(id: FullStoreDownloadProgressWindow.sceneID)
+        #endif
     }
-
-    private func canDownloadFullStore(contentLevel: ChineseCalendarSeedStoreContentLevel) -> Bool {
-        fullStoreConfiguration != nil && contentLevel != .full
-    }
-
-    private func storeIdentity(
-        contentLevel: ChineseCalendarSeedStoreContentLevel,
-        identityToken: String?
-    ) -> String {
-        "\(contentLevel.rawValue)-\(identityToken ?? "unknown")"
-    }
-
-    private func showDownloadErrorIfStoreRecovers(_ message: String) {
-        do {
-            let container = try ChineseCalendarModelContainerFactory.makeSharedContainer()
-            let contentLevel = try ChineseCalendarModelContainerFactory.installedStoreContentLevel() ?? .base
-            let identityToken = try ChineseCalendarModelContainerFactory.installedStoreIdentityToken()
-            state = .ready(container: container, contentLevel: contentLevel, identityToken: identityToken)
-            downloadErrorMessage = message
-        } catch {
-            ChineseCalendarLog.persistence.error("Failed to recover SwiftData store: \(error.localizedDescription)")
-            downloadErrorMessage = nil
-            state = .failed(message: message)
-        }
-    }
-}
-
-private enum CalendarStoreBootstrapState {
-    case starting
-    case ready(
-        container: ModelContainer,
-        contentLevel: ChineseCalendarSeedStoreContentLevel,
-        identityToken: String?
-    )
-    case downloading(progress: Double?)
-    case validating
-    case installing
-    case failed(message: String)
 }
 
 private struct FullStoreDownloadBanner: View {

--- a/Sources/ChineseCalendarUI/ChineseCalendarStoreCoordinator.swift
+++ b/Sources/ChineseCalendarUI/ChineseCalendarStoreCoordinator.swift
@@ -1,0 +1,206 @@
+import ChineseCalendarLogging
+import ChineseCalendarPersistence
+import Foundation
+import Observation
+import SwiftData
+
+@MainActor
+@Observable
+public final class ChineseCalendarStoreCoordinator {
+    private(set) var state: CalendarStoreBootstrapState = .starting
+    private(set) var fullStoreDownloadProgress: FullStoreDownloadProgress?
+    private(set) var downloadErrorMessage: String?
+    private(set) var isClearingDownloadedData = false
+
+    @ObservationIgnored private var fullStoreDownloadTask: Task<Void, Never>?
+    @ObservationIgnored private var clearCompletedDownloadTask: Task<Void, Never>?
+
+    private let fullStoreConfiguration: FullSeedStoreConfig?
+    private let seedStoreBundle: Bundle
+
+    public init(
+        fullStoreConfiguration: FullSeedStoreConfig? = .fromBundle(),
+        seedStoreBundle: Bundle = .main
+    ) {
+        self.fullStoreConfiguration = fullStoreConfiguration
+        self.seedStoreBundle = seedStoreBundle
+    }
+
+    func prepareStoreIfNeeded() async {
+        guard case .starting = state else {
+            return
+        }
+
+        prepareStore()
+    }
+
+    func prepareStore() {
+        do {
+            let container = try ChineseCalendarModelContainerFactory.makeSharedContainer()
+            let contentLevel = try ChineseCalendarModelContainerFactory.installedStoreContentLevel() ?? .base
+            let identityToken = try ChineseCalendarModelContainerFactory.installedStoreIdentityToken()
+            state = .ready(container: container, contentLevel: contentLevel, identityToken: identityToken)
+        } catch {
+            ChineseCalendarLog.persistence.error("Failed to prepare SwiftData store: \(error.localizedDescription)")
+            state = .failed(message: error.localizedDescription)
+        }
+    }
+
+    @discardableResult
+    func startFullStoreDownload() -> Bool {
+        guard let fullStoreConfiguration,
+              fullStoreDownloadTask == nil,
+              !isClearingDownloadedData
+        else {
+            return false
+        }
+
+        downloadErrorMessage = nil
+        clearCompletedDownloadTask?.cancel()
+        fullStoreDownloadProgress = .preparingManifest
+
+        fullStoreDownloadTask = Task { [fullStoreConfiguration] in
+            await downloadAndInstallFullStore(configuration: fullStoreConfiguration)
+        }
+
+        return true
+    }
+
+    func canDownloadFullStore(contentLevel: ChineseCalendarSeedStoreContentLevel) -> Bool {
+        fullStoreConfiguration != nil && contentLevel != .full && fullStoreDownloadTask == nil &&
+            !isClearingDownloadedData
+    }
+
+    func dismissDownloadError() {
+        downloadErrorMessage = nil
+    }
+
+    func storeIdentity(
+        contentLevel: ChineseCalendarSeedStoreContentLevel,
+        identityToken: String?
+    ) -> String {
+        "\(contentLevel.rawValue)-\(identityToken ?? "unknown")"
+    }
+
+    func clearDownloadedData() async throws {
+        guard !isClearingDownloadedData else {
+            return
+        }
+
+        isClearingDownloadedData = true
+        defer {
+            isClearingDownloadedData = false
+        }
+
+        let activeDownloadTask = fullStoreDownloadTask
+        activeDownloadTask?.cancel()
+        await activeDownloadTask?.value
+
+        clearCompletedDownloadTask?.cancel()
+        clearCompletedDownloadTask = nil
+        fullStoreDownloadTask = nil
+        fullStoreDownloadProgress = nil
+
+        let storeURL = try ChineseCalendarModelContainerFactory.clearDownloadedSeedStore(bundle: seedStoreBundle)
+        let container = try ChineseCalendarModelContainerFactory.makeContainer(
+            at: storeURL,
+            allowsSave: false
+        )
+        let contentLevel = try ChineseCalendarModelContainerFactory.installedStoreContentLevel() ?? .base
+        let identityToken = try ChineseCalendarModelContainerFactory.installedStoreIdentityToken()
+        state = .ready(container: container, contentLevel: contentLevel, identityToken: identityToken)
+    }
+
+    private func downloadAndInstallFullStore(
+        configuration: FullSeedStoreConfig
+    ) async {
+        let installer = ChineseCalendarFullSeedStoreInstaller(configuration: configuration)
+
+        do {
+            for try await event in await installer.installEvents() {
+                switch event {
+                case let .downloading(progress):
+                    fullStoreDownloadProgress = .downloading(progress: progress)
+                case .validating:
+                    fullStoreDownloadProgress = .validating
+                case .installing:
+                    fullStoreDownloadProgress = .installing
+                case let .installed(result):
+                    fullStoreDownloadProgress = .completed
+                    let container = try ChineseCalendarModelContainerFactory.makeContainer(
+                        at: result.storeURL,
+                        allowsSave: false
+                    )
+                    state = .ready(
+                        container: container,
+                        contentLevel: .full,
+                        identityToken: result.manifest.datasetVersion
+                    )
+                    fullStoreDownloadTask = nil
+                    clearCompletedDownloadProgressAfterDelay()
+                }
+            }
+        } catch {
+            fullStoreDownloadTask = nil
+            fullStoreDownloadProgress = nil
+            if isCancellation(error) {
+                return
+            }
+
+            ChineseCalendarLog.persistence
+                .error("Failed to install full SwiftData store: \(error.localizedDescription)")
+            showDownloadErrorIfStoreRecovers(error.localizedDescription)
+        }
+    }
+
+    private func clearCompletedDownloadProgressAfterDelay() {
+        clearCompletedDownloadTask?.cancel()
+        clearCompletedDownloadTask = Task {
+            do {
+                try await Task.sleep(for: .seconds(2))
+            } catch {
+                return
+            }
+
+            guard fullStoreDownloadProgress?.phase == .completed else {
+                return
+            }
+
+            fullStoreDownloadProgress = nil
+            clearCompletedDownloadTask = nil
+        }
+    }
+
+    private func showDownloadErrorIfStoreRecovers(_ message: String) {
+        do {
+            let container = try ChineseCalendarModelContainerFactory.makeSharedContainer()
+            let contentLevel = try ChineseCalendarModelContainerFactory.installedStoreContentLevel() ?? .base
+            let identityToken = try ChineseCalendarModelContainerFactory.installedStoreIdentityToken()
+            state = .ready(container: container, contentLevel: contentLevel, identityToken: identityToken)
+            downloadErrorMessage = message
+        } catch {
+            ChineseCalendarLog.persistence.error("Failed to recover SwiftData store: \(error.localizedDescription)")
+            downloadErrorMessage = nil
+            state = .failed(message: message)
+        }
+    }
+
+    private func isCancellation(_ error: Error) -> Bool {
+        if error is CancellationError || Task.isCancelled {
+            return true
+        }
+
+        let nsError = error as NSError
+        return nsError.domain == NSURLErrorDomain && nsError.code == NSURLErrorCancelled
+    }
+}
+
+enum CalendarStoreBootstrapState {
+    case starting
+    case ready(
+        container: ModelContainer,
+        contentLevel: ChineseCalendarSeedStoreContentLevel,
+        identityToken: String?
+    )
+    case failed(message: String)
+}

--- a/Sources/ChineseCalendarUI/FullStoreDownloadProgress.swift
+++ b/Sources/ChineseCalendarUI/FullStoreDownloadProgress.swift
@@ -1,0 +1,95 @@
+import Foundation
+
+enum FullStoreDownloadPhase: Equatable {
+    case preparingManifest
+    case downloading
+    case validating
+    case installing
+    case completed
+}
+
+struct FullStoreDownloadProgress: Equatable {
+    let phase: FullStoreDownloadPhase
+    let downloadProgress: Double?
+
+    static let preparingManifest = Self(phase: .preparingManifest, downloadProgress: nil)
+    static let validating = Self(phase: .validating, downloadProgress: nil)
+    static let installing = Self(phase: .installing, downloadProgress: nil)
+    static let completed = Self(phase: .completed, downloadProgress: 1)
+
+    static func downloading(progress: Double?) -> Self {
+        Self(phase: .downloading, downloadProgress: progress)
+    }
+
+    var fractionCompleted: Double {
+        switch phase {
+        case .preparingManifest:
+            0.03
+        case .downloading:
+            0.05 + (boundedDownloadProgress ?? 0) * 0.82
+        case .validating:
+            0.9
+        case .installing:
+            0.97
+        case .completed:
+            1
+        }
+    }
+
+    var title: String {
+        switch phase {
+        case .preparingManifest:
+            "正在准备完整日历数据"
+        case .downloading:
+            "正在下载完整日历数据"
+        case .validating:
+            "正在校验完整日历数据"
+        case .installing:
+            "正在安装完整日历数据"
+        case .completed:
+            "完整日历数据已安装"
+        }
+    }
+
+    var detail: String {
+        switch phase {
+        case .preparingManifest:
+            "正在获取下载清单。"
+        case .downloading:
+            if let boundedDownloadProgress {
+                "已下载 \(boundedDownloadProgress.formatted(.percent.precision(.fractionLength(0))))。"
+            } else {
+                "已连接下载源，正在计算文件大小。"
+            }
+        case .validating:
+            "正在检查文件大小和校验和。"
+        case .installing:
+            "正在替换本地数据存储。"
+        case .completed:
+            "现在可以浏览每日干支和对应公历日期。"
+        }
+    }
+
+    var systemImage: String {
+        switch phase {
+        case .preparingManifest:
+            "doc.text.magnifyingglass"
+        case .downloading:
+            "arrow.down.circle"
+        case .validating:
+            "checkmark.shield"
+        case .installing:
+            "externaldrive.badge.checkmark"
+        case .completed:
+            "checkmark.circle.fill"
+        }
+    }
+
+    private var boundedDownloadProgress: Double? {
+        guard let downloadProgress else {
+            return nil
+        }
+
+        return min(1, max(0, downloadProgress))
+    }
+}

--- a/Sources/ChineseCalendarUI/FullStoreDownloadProgressViews.swift
+++ b/Sources/ChineseCalendarUI/FullStoreDownloadProgressViews.swift
@@ -1,0 +1,140 @@
+import SwiftUI
+
+public struct FullStoreDownloadProgressWindow: View {
+    public static let sceneID = "full-store-download-progress"
+
+    private let coordinator: ChineseCalendarStoreCoordinator
+
+    public init(coordinator: ChineseCalendarStoreCoordinator) {
+        self.coordinator = coordinator
+    }
+
+    public var body: some View {
+        Group {
+            if let progress = coordinator.fullStoreDownloadProgress {
+                FullStoreDownloadProgressContent(progress: progress)
+                    .padding(20)
+            } else {
+                ContentUnavailableView(
+                    "没有正在下载的数据",
+                    systemImage: "checkmark.circle",
+                    description: Text("开始下载完整日期数据后，进度会显示在这里。")
+                )
+                .padding()
+            }
+        }
+        .frame(minWidth: 360, idealWidth: 420, minHeight: 180, idealHeight: 220)
+    }
+}
+
+struct FullStoreDownloadBottomProgressView: View {
+    let progress: FullStoreDownloadProgress
+
+    @State private var isExpanded = false
+
+    var body: some View {
+        Button {
+            withAnimation(.snappy) {
+                isExpanded.toggle()
+            }
+        } label: {
+            VStack(alignment: .leading, spacing: 10) {
+                HStack(spacing: 10) {
+                    Image(systemName: progress.systemImage)
+                        .font(.title3)
+                        .foregroundStyle(.tint)
+                        .frame(width: 24)
+
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text(progress.title)
+                            .font(.callout.weight(.semibold))
+                        ProgressView(value: progress.fractionCompleted)
+                    }
+
+                    Text(progress.fractionCompleted, format: .percent.precision(.fractionLength(0)))
+                        .font(.footnote.monospacedDigit())
+                        .foregroundStyle(.secondary)
+
+                    Image(systemName: "chevron.up")
+                        .font(.caption.weight(.semibold))
+                        .foregroundStyle(.secondary)
+                        .rotationEffect(isExpanded ? .zero : .degrees(180))
+                }
+
+                if isExpanded {
+                    Text(progress.detail)
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .transition(.opacity.combined(with: .move(edge: .bottom)))
+                }
+            }
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .padding(.horizontal)
+        .padding(.vertical, 12)
+        .background(.bar)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("\(progress.title)，\(progress.detail)")
+        .accessibilityValue(progress.fractionCompleted.formatted(.percent.precision(.fractionLength(0))))
+    }
+}
+
+struct FullStoreDownloadMacStatusBar: View {
+    let progress: FullStoreDownloadProgress
+    let openProgressWindow: () -> Void
+
+    var body: some View {
+        HStack(spacing: 12) {
+            Label(progress.title, systemImage: progress.systemImage)
+                .font(.callout)
+
+            ProgressView(value: progress.fractionCompleted)
+                .frame(maxWidth: 180)
+
+            Text(progress.fractionCompleted, format: .percent.precision(.fractionLength(0)))
+                .font(.footnote.monospacedDigit())
+                .foregroundStyle(.secondary)
+
+            Spacer(minLength: 12)
+
+            Button("查看进度", systemImage: "arrow.up.forward.app", action: openProgressWindow)
+                .buttonStyle(.bordered)
+        }
+        .padding(.horizontal)
+        .padding(.vertical, 10)
+        .background(.bar)
+        .accessibilityElement(children: .contain)
+    }
+}
+
+private struct FullStoreDownloadProgressContent: View {
+    let progress: FullStoreDownloadProgress
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            Label(progress.title, systemImage: progress.systemImage)
+                .font(.headline)
+
+            VStack(alignment: .leading, spacing: 8) {
+                HStack {
+                    Text(progress.detail)
+                        .font(.callout)
+                        .foregroundStyle(.secondary)
+
+                    Spacer()
+
+                    Text(progress.fractionCompleted, format: .percent.precision(.fractionLength(0)))
+                        .font(.callout.monospacedDigit())
+                        .foregroundStyle(.secondary)
+                }
+
+                ProgressView(value: progress.fractionCompleted)
+            }
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("\(progress.title)，\(progress.detail)")
+        .accessibilityValue(progress.fractionCompleted.formatted(.percent.precision(.fractionLength(0))))
+    }
+}


### PR DESCRIPTION
## Summary
- keep the main calendar usable while full data downloads run
- add determinate progress surfaces on iOS and macOS
- add settings controls to clear downloaded data and restore bundled base data

Fixes #36

## Verification
- swift build --package-path Sources
- swift test --package-path Sources
- ./Scripts/format.sh --check
- ./Scripts/lint.sh
- xcodebuild iOS simulator build
- xcodebuild macOS build