### PR TITLE
chore: add worktree setup skill

### DIFF
--- a/.codex/skills/worktree-setup/SKILL.md
+++ b/.codex/skills/worktree-setup/SKILL.md
@@ -1,0 +1,140 @@
+---
+name: worktree-setup
+description: Creates a branch worktree, creates or reuses a branch-scoped iPhone 17 Pro simulator, then updates XcodeBuildMCP simulator defaults.
+license: MIT
+metadata:
+  author: Tiger Guo
+  version: "1.0"
+---
+
+Set up an isolated branch workspace for this repository and wire a branch-scoped simulator UUID into XcodeBuildMCP defaults.
+
+## Inputs
+
+- Optional: branch name (for example: `feature/my-change`)
+- If branch name is not provided, infer it from user intent:
+1. Derive a concise semantic slug from the requested task.
+1. Use branch style `type/slug` where `type` is one of `feat`, `fix`, `chore`, `refactor`, `docs`, `test`.
+1. Example: "set up worktree skill" -> `chore/worktree-setup`.
+
+## Workflow
+
+1. Resolve paths:
+1. Repository root: `/Users/tigerguo/git/Chinese-date`
+1. Worktree root: `~/worktrees/chinese-date`
+1. Worktree path: `~/worktrees/chinese-date/<sanitized-branchname>`
+1. MCP config: `/Users/tigerguo/git/Chinese-date/.xcodebuildmcp/config.yaml`
+1. Ensure the worktree root directory exists.
+1. Create or reuse branch behavior:
+1. If the local branch exists, use it.
+1. If the local branch does not exist, create it from current `HEAD`.
+1. If the branch name contains slashes, replace them with dashes in the worktree directory name (for example: `feature/my-change` -> `feature-my-change`).
+1. For worktree creation at `~/worktrees/chinese-date/<sanitized-branchname>`:
+1. If a worktree already exists at that path for the same branch, reuse it.
+1. If it exists for a different branch, fail with an error.
+1. Create or reuse a simulator for this branch:
+1. Resolve latest available iOS runtime dynamically.
+1. Resolve iPhone 17 Pro device type dynamically.
+1. Use simulator name `iPhone 17 Pro (<sanitized-branchname>)`.
+1. If a simulator with that exact name already exists, reuse its UUID.
+1. Otherwise create it and capture the returned UUID.
+1. Update `/Users/tigerguo/git/Chinese-date/.xcodebuildmcp/config.yaml`:
+1. Set `sessionDefaults.simulatorId` to the new UUID.
+1. Ensure `sessionDefaults.simulatorName` is `iPhone 17 Pro (<sanitized-branchname>)`.
+1. Validate end state:
+1. `git worktree list` contains `~/worktrees/chinese-date/<sanitized-branchname>`.
+1. `xcrun simctl list devices` contains created UUID.
+1. Config file `sessionDefaults.simulatorId` equals created UUID.
+
+## Guardrails
+
+- Do not delete existing worktrees or simulators as part of this flow.
+- Fail fast if runtime or device type cannot be resolved.
+- If the config file does not exist, stop and report an error instead of creating it.
+- If `sessionDefaults` is missing from config, stop and report instead of writing malformed YAML.
+- Prefer YAML-aware edits (`yq`) when available. If unavailable, use a constrained key replacement only for `simulatorId` and `simulatorName`.
+- After editing with the fallback method, verify the expected values were written. If replacements do not occur, fail with an error.
+
+## Suggested command sequence
+
+```bash
+set -euo pipefail
+
+REPO_ROOT="/Users/tigerguo/git/Chinese-date"
+BRANCH_NAME="${1:-}"
+if [[ -z "$BRANCH_NAME" ]]; then
+  BRANCH_NAME="chore/worktree-setup"
+fi
+SANITIZED_BRANCH_NAME="${BRANCH_NAME//\//-}"
+WORKTREE_ROOT="$HOME/worktrees/chinese-date"
+WORKTREE_PATH="$WORKTREE_ROOT/$SANITIZED_BRANCH_NAME"
+CONFIG_FILE="$REPO_ROOT/.xcodebuildmcp/config.yaml"
+SIM_NAME="iPhone 17 Pro ($SANITIZED_BRANCH_NAME)"
+
+mkdir -p "$WORKTREE_ROOT"
+
+if git -C "$REPO_ROOT" show-ref --verify --quiet "refs/heads/$BRANCH_NAME"; then
+  :
+else
+  git -C "$REPO_ROOT" branch "$BRANCH_NAME"
+fi
+
+if [[ -d "$WORKTREE_PATH" ]]; then
+  EXISTING_BRANCH="$(git -C "$WORKTREE_PATH" branch --show-current 2>/dev/null || true)"
+  if [[ "$EXISTING_BRANCH" == "$BRANCH_NAME" ]]; then
+    :
+  else
+    echo "Worktree path exists for a different branch: $WORKTREE_PATH ($EXISTING_BRANCH)" >&2
+    exit 1
+  fi
+else
+  git -C "$REPO_ROOT" worktree add "$WORKTREE_PATH" "$BRANCH_NAME"
+fi
+
+if [[ ! -f "$CONFIG_FILE" ]]; then
+  echo "Missing config file: $CONFIG_FILE" >&2
+  exit 1
+fi
+
+RUNTIME_ID="$(xcrun simctl list runtimes -j | jq -r '.runtimes[] | select(.identifier | startswith("com.apple.CoreSimulator.SimRuntime.iOS-")) | select(.isAvailable == true) | .identifier' | tail -n 1)"
+DEVICE_TYPE_ID="$(xcrun simctl list devicetypes -j | jq -r '.devicetypes[] | select(.name == "iPhone 17 Pro") | .identifier' | head -n 1)"
+
+if [[ -z "$RUNTIME_ID" || -z "$DEVICE_TYPE_ID" ]]; then
+  echo "Unable to resolve runtime or iPhone 17 Pro device type." >&2
+  exit 1
+fi
+
+SIM_UUID="$(xcrun simctl list devices -j | jq -r --arg name "$SIM_NAME" '.devices | to_entries[] | .value[] | select(.name == $name and .isAvailable == true) | .udid' | head -n 1)"
+if [[ -z "$SIM_UUID" ]]; then
+  SIM_UUID="$(xcrun simctl create "$SIM_NAME" "$DEVICE_TYPE_ID" "$RUNTIME_ID")"
+fi
+
+if command -v yq >/dev/null 2>&1; then
+  yq -i '.sessionDefaults.simulatorId = strenv(SIM_UUID)' "$CONFIG_FILE"
+  yq -i '.sessionDefaults.simulatorName = strenv(SIM_NAME)' "$CONFIG_FILE"
+else
+  perl -i -pe 's/^(\s*simulatorId:\s*).*$/$1$ENV{SIM_UUID}/' "$CONFIG_FILE"
+  perl -i -pe 's/^(\s*simulatorName:\s*).*$/$1$ENV{SIM_NAME}/' "$CONFIG_FILE"
+
+  grep -Eq "^\s*simulatorId:\s*$SIM_UUID$" "$CONFIG_FILE" || {
+    echo "Fallback edit did not update simulatorId" >&2
+    exit 1
+  }
+  grep -Eq "^\s*simulatorName:\s*$SIM_NAME$" "$CONFIG_FILE" || {
+    echo "Fallback edit did not update simulatorName" >&2
+    exit 1
+  }
+fi
+
+git -C "$REPO_ROOT" worktree list | grep -F "$WORKTREE_PATH"
+xcrun simctl list devices | grep -F "$SIM_UUID"
+grep -n "simulatorId:" "$CONFIG_FILE"
+```
+
+## Output expectations
+
+Provide a concise summary with:
+
+1. Branch and worktree path created/used.
+1. New simulator UUID.
+1. Final `sessionDefaults.simulatorId` value in config.

--- a/.codex/skills/worktree-setup/agents/openai.yaml
+++ b/.codex/skills/worktree-setup/agents/openai.yaml
@@ -1,0 +1,10 @@
+interface:
+  display_name: "Worktree Setup"
+  short_description: "Creates a worktree, creates a new simulator, and updates MCP config."
+  icon_small: "./assets/worktree-setup-icon.svg"
+  icon_large: "./assets/worktree-setup-icon.svg"
+  brand_color: "#0C7D69"
+  default_prompt: "Use $worktree-setup for branch worktree and simulator setup."
+
+policy:
+  allow_implicit_invocation: true

--- a/.codex/skills/worktree-setup/assets/worktree-setup-icon.svg
+++ b/.codex/skills/worktree-setup/assets/worktree-setup-icon.svg
@@ -1,0 +1,10 @@
+<svg width="256" height="256" viewBox="0 0 256 256" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Worktree simulator setup icon">
+  <rect width="256" height="256" rx="36" fill="#0C7D69"/>
+  <path d="M52 72h96a8 8 0 0 1 8 8v22H44V80a8 8 0 0 1 8-8Zm-8 42h112v54a8 8 0 0 1-8 8H52a8 8 0 0 1-8-8v-54Z" fill="#E8FFF8"/>
+  <rect x="58" y="127" width="84" height="7" rx="3.5" fill="#0C7D69"/>
+  <rect x="58" y="142" width="55" height="7" rx="3.5" fill="#0C7D69"/>
+  <path d="M170 98h34a8 8 0 0 1 8 8v56a8 8 0 0 1-8 8h-34a8 8 0 0 1-8-8v-56a8 8 0 0 1 8-8Z" fill="#E8FFF8"/>
+  <circle cx="187" cy="155" r="4" fill="#0C7D69"/>
+  <path d="M186 78 172 92l14 14" fill="none" stroke="#E8FFF8" stroke-width="8" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="m196 110 14-14-14-14" fill="none" stroke="#E8FFF8" stroke-width="8" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -40,3 +40,4 @@ Use these workspace skills when relevant:
 - `swiftui-pro` for SwiftUI generation/review.
 - `swift-concurrency-pro` for async/await, actor isolation, cancellation, and task structure.
 - `swiftdata-pro` for SwiftData models, predicates, indexing, and CloudKit-related constraints.
+- `worktree-setup` for creating a branch worktree at `~/worktrees/chinese-date/<branchname>`, creating a new iPhone 17 Pro simulator, and updating `.xcodebuildmcp/config.yaml` simulator defaults.

--- a/.github/skills/worktree-setup/SKILL.md
+++ b/.github/skills/worktree-setup/SKILL.md
@@ -1,0 +1,140 @@
+---
+name: worktree-setup
+description: Creates a branch worktree, creates or reuses a branch-scoped iPhone 17 Pro simulator, then updates XcodeBuildMCP simulator defaults.
+license: MIT
+metadata:
+  author: Tiger Guo
+  version: "1.0"
+---
+
+Set up an isolated branch workspace for this repository and wire a branch-scoped simulator UUID into XcodeBuildMCP defaults.
+
+## Inputs
+
+- Optional: branch name (for example: `feature/my-change`)
+- If branch name is not provided, infer it from user intent:
+1. Derive a concise semantic slug from the requested task.
+1. Use branch style `type/slug` where `type` is one of `feat`, `fix`, `chore`, `refactor`, `docs`, `test`.
+1. Example: "set up worktree skill" -> `chore/worktree-setup`.
+
+## Workflow
+
+1. Resolve paths:
+1. Repository root: `/Users/tigerguo/git/Chinese-date`
+1. Worktree root: `~/worktrees/chinese-date`
+1. Worktree path: `~/worktrees/chinese-date/<sanitized-branchname>`
+1. MCP config: `/Users/tigerguo/git/Chinese-date/.xcodebuildmcp/config.yaml`
+1. Ensure the worktree root directory exists.
+1. Create or reuse branch behavior:
+1. If the local branch exists, use it.
+1. If the local branch does not exist, create it from current `HEAD`.
+1. If the branch name contains slashes, replace them with dashes in the worktree directory name (for example: `feature/my-change` -> `feature-my-change`).
+1. For worktree creation at `~/worktrees/chinese-date/<sanitized-branchname>`:
+1. If a worktree already exists at that path for the same branch, reuse it.
+1. If it exists for a different branch, fail with an error.
+1. Create or reuse a simulator for this branch:
+1. Resolve latest available iOS runtime dynamically.
+1. Resolve iPhone 17 Pro device type dynamically.
+1. Use simulator name `iPhone 17 Pro (<sanitized-branchname>)`.
+1. If a simulator with that exact name already exists, reuse its UUID.
+1. Otherwise create it and capture the returned UUID.
+1. Update `/Users/tigerguo/git/Chinese-date/.xcodebuildmcp/config.yaml`:
+1. Set `sessionDefaults.simulatorId` to the new UUID.
+1. Ensure `sessionDefaults.simulatorName` is `iPhone 17 Pro (<sanitized-branchname>)`.
+1. Validate end state:
+1. `git worktree list` contains `~/worktrees/chinese-date/<sanitized-branchname>`.
+1. `xcrun simctl list devices` contains created UUID.
+1. Config file `sessionDefaults.simulatorId` equals created UUID.
+
+## Guardrails
+
+- Do not delete existing worktrees or simulators as part of this flow.
+- Fail fast if runtime or device type cannot be resolved.
+- If the config file does not exist, stop and report an error instead of creating it.
+- If `sessionDefaults` is missing from config, stop and report instead of writing malformed YAML.
+- Prefer YAML-aware edits (`yq`) when available. If unavailable, use a constrained key replacement only for `simulatorId` and `simulatorName`.
+- After editing with the fallback method, verify the expected values were written. If replacements do not occur, fail with an error.
+
+## Suggested command sequence
+
+```bash
+set -euo pipefail
+
+REPO_ROOT="/Users/tigerguo/git/Chinese-date"
+BRANCH_NAME="${1:-}"
+if [[ -z "$BRANCH_NAME" ]]; then
+  BRANCH_NAME="chore/worktree-setup"
+fi
+SANITIZED_BRANCH_NAME="${BRANCH_NAME//\//-}"
+WORKTREE_ROOT="$HOME/worktrees/chinese-date"
+WORKTREE_PATH="$WORKTREE_ROOT/$SANITIZED_BRANCH_NAME"
+CONFIG_FILE="$REPO_ROOT/.xcodebuildmcp/config.yaml"
+SIM_NAME="iPhone 17 Pro ($SANITIZED_BRANCH_NAME)"
+
+mkdir -p "$WORKTREE_ROOT"
+
+if git -C "$REPO_ROOT" show-ref --verify --quiet "refs/heads/$BRANCH_NAME"; then
+  :
+else
+  git -C "$REPO_ROOT" branch "$BRANCH_NAME"
+fi
+
+if [[ -d "$WORKTREE_PATH" ]]; then
+  EXISTING_BRANCH="$(git -C "$WORKTREE_PATH" branch --show-current 2>/dev/null || true)"
+  if [[ "$EXISTING_BRANCH" == "$BRANCH_NAME" ]]; then
+    :
+  else
+    echo "Worktree path exists for a different branch: $WORKTREE_PATH ($EXISTING_BRANCH)" >&2
+    exit 1
+  fi
+else
+  git -C "$REPO_ROOT" worktree add "$WORKTREE_PATH" "$BRANCH_NAME"
+fi
+
+if [[ ! -f "$CONFIG_FILE" ]]; then
+  echo "Missing config file: $CONFIG_FILE" >&2
+  exit 1
+fi
+
+RUNTIME_ID="$(xcrun simctl list runtimes -j | jq -r '.runtimes[] | select(.identifier | startswith("com.apple.CoreSimulator.SimRuntime.iOS-")) | select(.isAvailable == true) | .identifier' | tail -n 1)"
+DEVICE_TYPE_ID="$(xcrun simctl list devicetypes -j | jq -r '.devicetypes[] | select(.name == "iPhone 17 Pro") | .identifier' | head -n 1)"
+
+if [[ -z "$RUNTIME_ID" || -z "$DEVICE_TYPE_ID" ]]; then
+  echo "Unable to resolve runtime or iPhone 17 Pro device type." >&2
+  exit 1
+fi
+
+SIM_UUID="$(xcrun simctl list devices -j | jq -r --arg name "$SIM_NAME" '.devices | to_entries[] | .value[] | select(.name == $name and .isAvailable == true) | .udid' | head -n 1)"
+if [[ -z "$SIM_UUID" ]]; then
+  SIM_UUID="$(xcrun simctl create "$SIM_NAME" "$DEVICE_TYPE_ID" "$RUNTIME_ID")"
+fi
+
+if command -v yq >/dev/null 2>&1; then
+  yq -i '.sessionDefaults.simulatorId = strenv(SIM_UUID)' "$CONFIG_FILE"
+  yq -i '.sessionDefaults.simulatorName = strenv(SIM_NAME)' "$CONFIG_FILE"
+else
+  perl -i -pe 's/^(\s*simulatorId:\s*).*$/$1$ENV{SIM_UUID}/' "$CONFIG_FILE"
+  perl -i -pe 's/^(\s*simulatorName:\s*).*$/$1$ENV{SIM_NAME}/' "$CONFIG_FILE"
+
+  grep -Eq "^\s*simulatorId:\s*$SIM_UUID$" "$CONFIG_FILE" || {
+    echo "Fallback edit did not update simulatorId" >&2
+    exit 1
+  }
+  grep -Eq "^\s*simulatorName:\s*$SIM_NAME$" "$CONFIG_FILE" || {
+    echo "Fallback edit did not update simulatorName" >&2
+    exit 1
+  }
+fi
+
+git -C "$REPO_ROOT" worktree list | grep -F "$WORKTREE_PATH"
+xcrun simctl list devices | grep -F "$SIM_UUID"
+grep -n "simulatorId:" "$CONFIG_FILE"
+```
+
+## Output expectations
+
+Provide a concise summary with:
+
+1. Branch and worktree path created/used.
+1. New simulator UUID.
+1. Final `sessionDefaults.simulatorId` value in config.

--- a/.github/skills/worktree-setup/agents/openai.yaml
+++ b/.github/skills/worktree-setup/agents/openai.yaml
@@ -1,0 +1,10 @@
+interface:
+  display_name: "Worktree Setup"
+  short_description: "Creates a worktree, creates a new simulator, and updates MCP config."
+  icon_small: "./assets/worktree-setup-icon.svg"
+  icon_large: "./assets/worktree-setup-icon.svg"
+  brand_color: "#0C7D69"
+  default_prompt: "Use $worktree-setup for branch worktree and simulator setup."
+
+policy:
+  allow_implicit_invocation: true

--- a/.github/skills/worktree-setup/assets/worktree-setup-icon.svg
+++ b/.github/skills/worktree-setup/assets/worktree-setup-icon.svg
@@ -1,0 +1,10 @@
+<svg width="256" height="256" viewBox="0 0 256 256" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Worktree simulator setup icon">
+  <rect width="256" height="256" rx="36" fill="#0C7D69"/>
+  <path d="M52 72h96a8 8 0 0 1 8 8v22H44V80a8 8 0 0 1 8-8Zm-8 42h112v54a8 8 0 0 1-8 8H52a8 8 0 0 1-8-8v-54Z" fill="#E8FFF8"/>
+  <rect x="58" y="127" width="84" height="7" rx="3.5" fill="#0C7D69"/>
+  <rect x="58" y="142" width="55" height="7" rx="3.5" fill="#0C7D69"/>
+  <path d="M170 98h34a8 8 0 0 1 8 8v56a8 8 0 0 1-8 8h-34a8 8 0 0 1-8-8v-56a8 8 0 0 1 8-8Z" fill="#E8FFF8"/>
+  <circle cx="187" cy="155" r="4" fill="#0C7D69"/>
+  <path d="M186 78 172 92l14 14" fill="none" stroke="#E8FFF8" stroke-width="8" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="m196 110 14-14-14-14" fill="none" stroke="#E8FFF8" stroke-width="8" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,6 +54,7 @@ This repository hosts a Swift project for browsing the traditional Chinese calen
 - Project-local Codex skill: `./.codex/skills/swiftui-pro`
 - Project-local Codex skill: `./.codex/skills/swift-concurrency-pro`
 - Project-local Codex skill: `./.codex/skills/swiftdata-pro`
+- Project-local Codex skill: `./.codex/skills/worktree-setup`
 - Upstream Swift agent index reference: `./Docs/AgentReferences/swift-agent-skills/README.md`
 - Upstream SwiftAgents reference: `./Docs/AgentReferences/SwiftAgents/AGENTS.upstream.md`
 


### PR DESCRIPTION
## Summary
- add the worktree-setup skill for Codex and GitHub Copilot skill directories
- document the new skill in AGENTS.md and Copilot instructions

## Tests
- Not run (agent skill documentation/configuration only).