### PR TITLE
Show settings button on year list

### DIFF
--- a/Sources/ChineseCalendarUI/CalendarHomeView.swift
+++ b/Sources/ChineseCalendarUI/CalendarHomeView.swift
@@ -9,11 +9,16 @@ public struct CalendarHomeView: View {
     @Query(sort: \ChineseLunarYear.lunarYearNumber) private var years: [ChineseLunarYear]
     @State private var router = CalendarRouter()
     @State private var didOpenColdLaunchDeepLink = false
+    private let openSettings: (() -> Void)?
 
-    public init() {}
+    public init(openSettings: (() -> Void)? = nil) {
+        self.openSettings = openSettings
+    }
 
     @available(*, deprecated, message: "CalendarHomeView now selects the current lunar year automatically.")
-    public init(selectedDate _: ChineseCalendarDate?) {}
+    public init(selectedDate _: ChineseCalendarDate?) {
+        self.init()
+    }
 
     public var body: some View {
         NavigationSplitView {
@@ -26,6 +31,15 @@ public struct CalendarHomeView: View {
                 }
             }
             .navigationTitle("年份")
+            #if os(iOS)
+                .toolbar {
+                    if let openSettings {
+                        ToolbarItem(placement: .topBarTrailing) {
+                            Button("设置", systemImage: "gearshape", action: openSettings)
+                        }
+                    }
+                }
+            #endif
         } detail: {
             CalendarRouteDestinationView(
                 route: router.selectedRoute,

--- a/Sources/ChineseCalendarUI/CalendarHomeView.swift
+++ b/Sources/ChineseCalendarUI/CalendarHomeView.swift
@@ -49,8 +49,7 @@ public struct CalendarHomeView: View {
                 canSelectNextYear: router.canSelectNextYear(availableYearNumbers: yearNumbers),
                 selectPreviousYear: { router.selectPreviousYear(availableYearNumbers: yearNumbers) },
                 selectNextYear: { router.selectNextYear(availableYearNumbers: yearNumbers) },
-                emptyStateDescription: emptyStateDescription,
-                openSettings: openSettings
+                emptyStateDescription: emptyStateDescription
             )
         }
         .sheet(item: $router.sheet, onDismiss: router.applyDeferredDeepLinkIfReady) { node in

--- a/Sources/ChineseCalendarUI/CalendarHomeView.swift
+++ b/Sources/ChineseCalendarUI/CalendarHomeView.swift
@@ -34,7 +34,7 @@ public struct CalendarHomeView: View {
             #if os(iOS)
                 .toolbar {
                     if let openSettings {
-                        ToolbarItem(placement: .topBarTrailing) {
+                        ToolbarItem(placement: .primaryAction) {
                             Button("设置", systemImage: "gearshape", action: openSettings)
                         }
                     }
@@ -49,7 +49,8 @@ public struct CalendarHomeView: View {
                 canSelectNextYear: router.canSelectNextYear(availableYearNumbers: yearNumbers),
                 selectPreviousYear: { router.selectPreviousYear(availableYearNumbers: yearNumbers) },
                 selectNextYear: { router.selectNextYear(availableYearNumbers: yearNumbers) },
-                emptyStateDescription: emptyStateDescription
+                emptyStateDescription: emptyStateDescription,
+                openSettings: openSettings
             )
         }
         .sheet(item: $router.sheet, onDismiss: router.applyDeferredDeepLinkIfReady) { node in

--- a/Sources/ChineseCalendarUI/CalendarRouteDestinationView.swift
+++ b/Sources/ChineseCalendarUI/CalendarRouteDestinationView.swift
@@ -10,7 +10,6 @@ struct CalendarRouteDestinationView: View {
     let selectPreviousYear: () -> Void
     let selectNextYear: () -> Void
     let emptyStateDescription: String
-    let openSettings: (() -> Void)?
 
     init(
         route: CalendarRoute?,
@@ -20,8 +19,7 @@ struct CalendarRouteDestinationView: View {
         canSelectNextYear: Bool,
         selectPreviousYear: @escaping () -> Void,
         selectNextYear: @escaping () -> Void,
-        emptyStateDescription: String,
-        openSettings: (() -> Void)? = nil
+        emptyStateDescription: String
     ) {
         self.route = route
         self.year = year
@@ -31,7 +29,6 @@ struct CalendarRouteDestinationView: View {
         self.selectPreviousYear = selectPreviousYear
         self.selectNextYear = selectNextYear
         self.emptyStateDescription = emptyStateDescription
-        self.openSettings = openSettings
     }
 
     var body: some View {
@@ -45,8 +42,7 @@ struct CalendarRouteDestinationView: View {
                         canSelectPreviousYear: canSelectPreviousYear,
                         canSelectNextYear: canSelectNextYear,
                         selectPreviousYear: selectPreviousYear,
-                        selectNextYear: selectNextYear,
-                        openSettings: openSettings
+                        selectNextYear: selectNextYear
                     )
                 } else {
                     ContentUnavailableView {

--- a/Sources/ChineseCalendarUI/CalendarRouteDestinationView.swift
+++ b/Sources/ChineseCalendarUI/CalendarRouteDestinationView.swift
@@ -10,6 +10,29 @@ struct CalendarRouteDestinationView: View {
     let selectPreviousYear: () -> Void
     let selectNextYear: () -> Void
     let emptyStateDescription: String
+    let openSettings: (() -> Void)?
+
+    init(
+        route: CalendarRoute?,
+        year: ChineseLunarYear?,
+        selectedMonthIndex: Binding<Int?>,
+        canSelectPreviousYear: Bool,
+        canSelectNextYear: Bool,
+        selectPreviousYear: @escaping () -> Void,
+        selectNextYear: @escaping () -> Void,
+        emptyStateDescription: String,
+        openSettings: (() -> Void)? = nil
+    ) {
+        self.route = route
+        self.year = year
+        _selectedMonthIndex = selectedMonthIndex
+        self.canSelectPreviousYear = canSelectPreviousYear
+        self.canSelectNextYear = canSelectNextYear
+        self.selectPreviousYear = selectPreviousYear
+        self.selectNextYear = selectNextYear
+        self.emptyStateDescription = emptyStateDescription
+        self.openSettings = openSettings
+    }
 
     var body: some View {
         Group {
@@ -22,7 +45,8 @@ struct CalendarRouteDestinationView: View {
                         canSelectPreviousYear: canSelectPreviousYear,
                         canSelectNextYear: canSelectNextYear,
                         selectPreviousYear: selectPreviousYear,
-                        selectNextYear: selectNextYear
+                        selectNextYear: selectNextYear,
+                        openSettings: openSettings
                     )
                 } else {
                     ContentUnavailableView {

--- a/Sources/ChineseCalendarUI/ChineseCalendarRootView.swift
+++ b/Sources/ChineseCalendarUI/ChineseCalendarRootView.swift
@@ -26,7 +26,7 @@ public struct ChineseCalendarRootView: View {
             case .starting:
                 CalendarStoreProgressView(title: "正在准备日历数据", progress: nil)
             case let .ready(container, contentLevel, identityToken):
-                CalendarHomeView()
+                CalendarHomeView(openSettings: showSettings)
                     .environment(\.calendarStoreContentLevel, contentLevel)
                     .modelContainer(container)
                     .id(coordinator.storeIdentity(contentLevel: contentLevel, identityToken: identityToken))
@@ -36,15 +36,6 @@ public struct ChineseCalendarRootView: View {
             case let .failed(message):
                 CalendarStoreFailureView(message: message, retry: coordinator.prepareStore)
             }
-        }
-        .toolbar {
-            #if os(iOS)
-                ToolbarItem(placement: .topBarTrailing) {
-                    Button("设置", systemImage: "gearshape") {
-                        isSettingsPresented = true
-                    }
-                }
-            #endif
         }
         .sheet(isPresented: $isSettingsPresented) {
             NavigationStack {
@@ -70,6 +61,10 @@ public struct ChineseCalendarRootView: View {
                 }
             }
         )
+    }
+
+    private func showSettings() {
+        isSettingsPresented = true
     }
 
     @ViewBuilder

--- a/Sources/ChineseCalendarUI/LunarYearDetailView.swift
+++ b/Sources/ChineseCalendarUI/LunarYearDetailView.swift
@@ -10,7 +10,6 @@ struct LunarYearDetailView: View {
     let canSelectNextYear: Bool
     let selectPreviousYear: () -> Void
     let selectNextYear: () -> Void
-    let openSettings: (() -> Void)?
 
     @Query private var months: [ChineseLunarMonth]
 
@@ -20,8 +19,7 @@ struct LunarYearDetailView: View {
         canSelectPreviousYear: Bool,
         canSelectNextYear: Bool,
         selectPreviousYear: @escaping () -> Void,
-        selectNextYear: @escaping () -> Void,
-        openSettings: (() -> Void)? = nil
+        selectNextYear: @escaping () -> Void
     ) {
         self.year = year
         _selectedMonthIndex = selectedMonthIndex
@@ -29,7 +27,6 @@ struct LunarYearDetailView: View {
         self.canSelectNextYear = canSelectNextYear
         self.selectPreviousYear = selectPreviousYear
         self.selectNextYear = selectNextYear
-        self.openSettings = openSettings
 
         let lunarYearNumber = year.lunarYearNumber
         _months = Query(
@@ -89,12 +86,6 @@ struct LunarYearDetailView: View {
                 Button("下一年", systemImage: "chevron.right", action: selectNextYear)
                     .disabled(!canSelectNextYear)
                     .help("切换到下一年")
-
-                #if os(iOS)
-                    if let openSettings {
-                        Button("设置", systemImage: "gearshape", action: openSettings)
-                    }
-                #endif
             }
         }
     }

--- a/Sources/ChineseCalendarUI/LunarYearDetailView.swift
+++ b/Sources/ChineseCalendarUI/LunarYearDetailView.swift
@@ -10,6 +10,7 @@ struct LunarYearDetailView: View {
     let canSelectNextYear: Bool
     let selectPreviousYear: () -> Void
     let selectNextYear: () -> Void
+    let openSettings: (() -> Void)?
 
     @Query private var months: [ChineseLunarMonth]
 
@@ -19,7 +20,8 @@ struct LunarYearDetailView: View {
         canSelectPreviousYear: Bool,
         canSelectNextYear: Bool,
         selectPreviousYear: @escaping () -> Void,
-        selectNextYear: @escaping () -> Void
+        selectNextYear: @escaping () -> Void,
+        openSettings: (() -> Void)? = nil
     ) {
         self.year = year
         _selectedMonthIndex = selectedMonthIndex
@@ -27,6 +29,7 @@ struct LunarYearDetailView: View {
         self.canSelectNextYear = canSelectNextYear
         self.selectPreviousYear = selectPreviousYear
         self.selectNextYear = selectNextYear
+        self.openSettings = openSettings
 
         let lunarYearNumber = year.lunarYearNumber
         _months = Query(
@@ -86,6 +89,12 @@ struct LunarYearDetailView: View {
                 Button("下一年", systemImage: "chevron.right", action: selectNextYear)
                     .disabled(!canSelectNextYear)
                     .help("切换到下一年")
+
+                #if os(iOS)
+                    if let openSettings {
+                        Button("设置", systemImage: "gearshape", action: openSettings)
+                    }
+                #endif
             }
         }
     }


### PR DESCRIPTION
## Summary
- Fixes the screenshot issue where the Year page had no Settings button in the top-right navigation bar.
- Moves the iOS settings toolbar item into the visible year list navigation column.

## Validation
- xcodebuildmcp swift-package build --package-path Sources
- xcodebuildmcp swift-package test --package-path Sources
- xcodebuildmcp simulator build --workspace-path Sources --scheme ChineseCalendarUI
- xcodebuildmcp macos build --workspace-path Sources --scheme ChineseCalendarUI
- xcodebuildmcp macos build --workspace-path Sources --scheme ChineseCalendarSources-Package