### PR TITLE
Refactor iOS navigation handling

### DIFF
--- a/Sources/ChineseCalendarUI/CalendarHistoryHomeView.swift
+++ b/Sources/ChineseCalendarUI/CalendarHistoryHomeView.swift
@@ -1,0 +1,32 @@
+import ChineseCalendarPersistence
+import SwiftData
+import SwiftUI
+
+struct CalendarHistoryHomeView: View {
+    @Query(sort: \OrthodoxPeriod.sequenceIndex) private var periods: [OrthodoxPeriod]
+
+    var body: some View {
+        List {
+            if periods.isEmpty {
+                ContentUnavailableView(
+                    "没有历史时间线数据",
+                    systemImage: "timeline.selection",
+                    description: Text("当前 SwiftData store 中没有可显示的正统时期。")
+                )
+            } else {
+                Section("主流中国王朝序列") {
+                    ForEach(periods, id: \.id) { period in
+                        if let dynastyID = period.dynasty?.id {
+                            NavigationLink(value: CalendarRoute.dynasty(dynastyID)) {
+                                OrthodoxPeriodRow(period: period)
+                            }
+                        } else {
+                            OrthodoxPeriodRow(period: period)
+                        }
+                    }
+                }
+            }
+        }
+        .navigationTitle("历史")
+    }
+}

--- a/Sources/ChineseCalendarUI/CalendarHomeSplitView.swift
+++ b/Sources/ChineseCalendarUI/CalendarHomeSplitView.swift
@@ -1,0 +1,54 @@
+import ChineseCalendarPersistence
+import SwiftUI
+
+struct CalendarHomeSplitView: View {
+    @Bindable var router: CalendarRouter
+    let years: [ChineseLunarYear]
+    let emptyStateDescription: String
+
+    var body: some View {
+        NavigationSplitView {
+            List(selection: selection) {
+                Section("农历年") {
+                    ForEach(years, id: \.lunarYearNumber) { year in
+                        LunarYearRow(year: year)
+                            .tag(CalendarRoute.lunarYear(year.lunarYearNumber))
+                    }
+                }
+            }
+            .navigationTitle("年份")
+        } detail: {
+            CalendarRouteDestinationView(
+                route: router.currentRoute(on: .years),
+                year: selectedYear,
+                selectedMonthIndex: $router.selectedMonthIndex,
+                canSelectPreviousYear: router.canSelectPreviousYear(availableYearNumbers: yearNumbers),
+                canSelectNextYear: router.canSelectNextYear(availableYearNumbers: yearNumbers),
+                selectPreviousYear: { router.selectPreviousYear(availableYearNumbers: yearNumbers) },
+                selectNextYear: { router.selectNextYear(availableYearNumbers: yearNumbers) },
+                emptyStateDescription: emptyStateDescription
+            )
+        }
+    }
+
+    private var selection: Binding<CalendarRoute?> {
+        Binding {
+            router.currentRoute(on: .years)
+        } set: { route in
+            router.selectedTab = .years
+            router.setPath(route.map { [$0] } ?? [], for: .years)
+        }
+    }
+
+    private var yearNumbers: [Int] {
+        years.map(\.lunarYearNumber)
+    }
+
+    private var selectedYear: ChineseLunarYear? {
+        guard let selectedYearNumber = router.selectedYearNumber else {
+            return nil
+        }
+
+        return years.first { $0.lunarYearNumber == selectedYearNumber }
+    }
+}

--- a/Sources/ChineseCalendarUI/CalendarHomeTabView.swift
+++ b/Sources/ChineseCalendarUI/CalendarHomeTabView.swift
@@ -1,0 +1,67 @@
+import ChineseCalendarPersistence
+import SwiftUI
+
+struct CalendarHomeTabView: View {
+    @Bindable var router: CalendarRouter
+    let years: [ChineseLunarYear]
+    let emptyStateDescription: String
+    let openSettings: (() -> Void)?
+
+    var body: some View {
+        TabView(selection: $router.selectedTab) {
+            NavigationStack(path: $router.yearsPath) {
+                CalendarYearsListView(years: years)
+                    .navigationDestination(for: CalendarRoute.self, destination: destination)
+                    .toolbar(content: settingsToolbar)
+            }
+            .tabItem {
+                Label(CalendarTab.years.title, systemImage: CalendarTab.years.systemImage)
+            }
+            .tag(CalendarTab.years)
+
+            NavigationStack(path: $router.historyPath) {
+                CalendarHistoryHomeView()
+                    .navigationDestination(for: CalendarRoute.self, destination: destination)
+                    .toolbar(content: settingsToolbar)
+            }
+            .tabItem {
+                Label(CalendarTab.history.title, systemImage: CalendarTab.history.systemImage)
+            }
+            .tag(CalendarTab.history)
+        }
+    }
+
+    @ToolbarContentBuilder
+    private func settingsToolbar() -> some ToolbarContent {
+        if let openSettings {
+            ToolbarItem(placement: .primaryAction) {
+                Button("设置", systemImage: "gearshape", action: openSettings)
+            }
+        }
+    }
+
+    private func destination(for route: CalendarRoute) -> some View {
+        CalendarRouteDestinationView(
+            route: route,
+            year: year(for: route),
+            selectedMonthIndex: $router.selectedMonthIndex,
+            canSelectPreviousYear: router.canSelectPreviousYear(availableYearNumbers: yearNumbers),
+            canSelectNextYear: router.canSelectNextYear(availableYearNumbers: yearNumbers),
+            selectPreviousYear: { router.selectPreviousYear(availableYearNumbers: yearNumbers) },
+            selectNextYear: { router.selectNextYear(availableYearNumbers: yearNumbers) },
+            emptyStateDescription: emptyStateDescription
+        )
+    }
+
+    private var yearNumbers: [Int] {
+        years.map(\.lunarYearNumber)
+    }
+
+    private func year(for route: CalendarRoute?) -> ChineseLunarYear? {
+        guard let yearNumber = route?.lunarYearNumber else {
+            return nil
+        }
+
+        return years.first { $0.lunarYearNumber == yearNumber }
+    }
+}

--- a/Sources/ChineseCalendarUI/CalendarHomeView.swift
+++ b/Sources/ChineseCalendarUI/CalendarHomeView.swift
@@ -21,36 +21,23 @@ public struct CalendarHomeView: View {
     }
 
     public var body: some View {
-        NavigationSplitView {
-            List(selection: $router.selectedRoute) {
-                Section("农历年") {
-                    ForEach(years, id: \.lunarYearNumber) { year in
-                        LunarYearRow(year: year)
-                            .tag(CalendarRoute.lunarYear(year.lunarYearNumber))
-                    }
-                }
-            }
-            .navigationTitle("年份")
+        @Bindable var router = router
+
+        Group {
             #if os(iOS)
-                .toolbar {
-                    if let openSettings {
-                        ToolbarItem(placement: .primaryAction) {
-                            Button("设置", systemImage: "gearshape", action: openSettings)
-                        }
-                    }
-                }
+                CalendarHomeTabView(
+                    router: router,
+                    years: years,
+                    emptyStateDescription: emptyStateDescription,
+                    openSettings: openSettings
+                )
+            #else
+                CalendarHomeSplitView(
+                    router: router,
+                    years: years,
+                    emptyStateDescription: emptyStateDescription
+                )
             #endif
-        } detail: {
-            CalendarRouteDestinationView(
-                route: router.selectedRoute,
-                year: selectedYear,
-                selectedMonthIndex: $router.selectedMonthIndex,
-                canSelectPreviousYear: router.canSelectPreviousYear(availableYearNumbers: yearNumbers),
-                canSelectNextYear: router.canSelectNextYear(availableYearNumbers: yearNumbers),
-                selectPreviousYear: { router.selectPreviousYear(availableYearNumbers: yearNumbers) },
-                selectNextYear: { router.selectNextYear(availableYearNumbers: yearNumbers) },
-                emptyStateDescription: emptyStateDescription
-            )
         }
         .sheet(item: $router.sheet, onDismiss: router.applyDeferredDeepLinkIfReady) { node in
             CalendarPresentationNodeView(node: node, years: years) {
@@ -74,18 +61,6 @@ public struct CalendarHomeView: View {
         }
     }
 
-    private var yearNumbers: [Int] {
-        years.map(\.lunarYearNumber)
-    }
-
-    private var selectedYear: ChineseLunarYear? {
-        guard let selectedYearNumber = router.selectedYearNumber else {
-            return nil
-        }
-
-        return years.first { $0.lunarYearNumber == selectedYearNumber }
-    }
-
     private var emptyStateDescription: String {
         if years.isEmpty {
             return "正在加载 SwiftData 日历数据。"
@@ -95,6 +70,7 @@ public struct CalendarHomeView: View {
     }
 
     private func selectDefaultYearIfNeeded() {
+        let yearNumbers = years.map(\.lunarYearNumber)
         guard !yearNumbers.isEmpty else {
             ChineseCalendarLog.ui.debug("CalendarHomeView is waiting for SwiftData years")
             return

--- a/Sources/ChineseCalendarUI/CalendarRoute.swift
+++ b/Sources/ChineseCalendarUI/CalendarRoute.swift
@@ -2,11 +2,14 @@ import Foundation
 
 enum CalendarRoute: Hashable, Identifiable {
     case lunarYear(Int)
+    case dynasty(String)
 
     var id: String {
         switch self {
         case let .lunarYear(yearNumber):
             "lunar-year-\(yearNumber)"
+        case let .dynasty(dynastyID):
+            "dynasty-\(dynastyID)"
         }
     }
 
@@ -14,12 +17,15 @@ enum CalendarRoute: Hashable, Identifiable {
         switch self {
         case let .lunarYear(yearNumber):
             yearNumber
+        case .dynasty:
+            nil
         }
     }
 }
 
 enum CalendarDeepLink: Equatable {
     case lunarYear(Int, monthIndex: Int? = nil)
+    case dynasty(String)
 }
 
 enum CalendarDeepLinkParser {
@@ -44,6 +50,12 @@ enum CalendarDeepLinkParser {
             }
 
             return .lunarYear(yearNumber, monthIndex: monthIndex)
+        case "dynasty":
+            guard parts.count >= 2 else {
+                return nil
+            }
+
+            return .dynasty(parts[1])
         default:
             guard let yearNumber = Int(firstPart) else {
                 return nil

--- a/Sources/ChineseCalendarUI/CalendarRouteDestinationView.swift
+++ b/Sources/ChineseCalendarUI/CalendarRouteDestinationView.swift
@@ -51,6 +51,8 @@ struct CalendarRouteDestinationView: View {
                         Text("没有找到这个农历年。")
                     }
                 }
+            case let .dynasty(dynastyID):
+                DynastyDetailView(dynastyID: dynastyID)
             case nil:
                 ContentUnavailableView {
                     Label("Chinese Calendar", systemImage: "calendar")

--- a/Sources/ChineseCalendarUI/CalendarRouter.swift
+++ b/Sources/ChineseCalendarUI/CalendarRouter.swift
@@ -4,34 +4,84 @@ import Observation
 @MainActor
 @Observable
 final class CalendarRouter {
-    var selectedRoute: CalendarRoute? {
+    var selectedTab: CalendarTab
+    var yearsPath: [CalendarRoute] {
         didSet {
-            if selectedRoute?.lunarYearNumber != oldValue?.lunarYearNumber {
-                selectedMonthIndex = nil
-            }
+            clearSelectedMonthIfSelectedYearChanged(from: oldValue, to: yearsPath)
         }
     }
 
+    var historyPath: [CalendarRoute]
     var selectedMonthIndex: Int?
     var sheet: CalendarPresentationNode?
     var fullScreen: CalendarPresentationNode?
     private(set) var deferredDeepLink: CalendarDeepLink?
 
+    var selectedRoute: CalendarRoute? {
+        get { currentRoute(on: selectedTab) }
+        set {
+            if let newValue {
+                setPath([newValue], for: selectedTab)
+            } else {
+                setPath([], for: selectedTab)
+            }
+        }
+    }
+
     var selectedYearNumber: Int? {
-        selectedRoute?.lunarYearNumber
+        currentRoute(on: .years)?.lunarYearNumber
     }
 
     var hasActivePresentation: Bool {
         sheet != nil || fullScreen != nil
     }
 
-    init(selectedRoute: CalendarRoute? = nil, selectedMonthIndex: Int? = nil) {
-        self.selectedRoute = selectedRoute
+    init(
+        selectedTab: CalendarTab = .years,
+        selectedRoute: CalendarRoute? = nil,
+        yearsPath: [CalendarRoute]? = nil,
+        historyPath: [CalendarRoute] = [],
+        selectedMonthIndex: Int? = nil
+    ) {
+        self.selectedTab = selectedTab
+        self.yearsPath = yearsPath ?? selectedRoute.map { [$0] } ?? []
+        self.historyPath = historyPath
         self.selectedMonthIndex = selectedMonthIndex
     }
 
+    func path(for tab: CalendarTab) -> [CalendarRoute] {
+        switch tab {
+        case .years:
+            yearsPath
+        case .history:
+            historyPath
+        }
+    }
+
+    func setPath(_ path: [CalendarRoute], for tab: CalendarTab) {
+        switch tab {
+        case .years:
+            yearsPath = path
+        case .history:
+            historyPath = path
+        }
+    }
+
+    func currentRoute(on tab: CalendarTab) -> CalendarRoute? {
+        path(for: tab).last
+    }
+
+    func push(_ route: CalendarRoute, on tab: CalendarTab? = nil) {
+        let targetTab = tab ?? selectedTab
+        selectedTab = targetTab
+        var path = path(for: targetTab)
+        path.append(route)
+        setPath(path, for: targetTab)
+    }
+
     func selectYear(_ yearNumber: Int, monthIndex: Int? = nil) {
-        selectedRoute = .lunarYear(yearNumber)
+        selectedTab = .years
+        setPath([.lunarYear(yearNumber)], for: .years)
         selectedMonthIndex = monthIndex
     }
 
@@ -145,7 +195,19 @@ final class CalendarRouter {
         switch deepLink {
         case let .lunarYear(yearNumber, monthIndex):
             selectYear(yearNumber, monthIndex: monthIndex)
+        case let .dynasty(dynastyID):
+            selectedTab = .history
+            setPath([.dynasty(dynastyID)], for: .history)
+            selectedMonthIndex = nil
         }
+    }
+
+    private func clearSelectedMonthIfSelectedYearChanged(from oldPath: [CalendarRoute], to newPath: [CalendarRoute]) {
+        guard oldPath.last?.lunarYearNumber != newPath.last?.lunarYearNumber else {
+            return
+        }
+
+        selectedMonthIndex = nil
     }
 }
 

--- a/Sources/ChineseCalendarUI/CalendarTab.swift
+++ b/Sources/ChineseCalendarUI/CalendarTab.swift
@@ -1,0 +1,28 @@
+import Foundation
+
+enum CalendarTab: Hashable, CaseIterable, Identifiable {
+    case years
+    case history
+
+    var id: Self {
+        self
+    }
+
+    var title: String {
+        switch self {
+        case .years:
+            "年份"
+        case .history:
+            "历史"
+        }
+    }
+
+    var systemImage: String {
+        switch self {
+        case .years:
+            "calendar"
+        case .history:
+            "timeline.selection"
+        }
+    }
+}

--- a/Sources/ChineseCalendarUI/CalendarYearsListView.swift
+++ b/Sources/ChineseCalendarUI/CalendarYearsListView.swift
@@ -1,0 +1,19 @@
+import ChineseCalendarPersistence
+import SwiftUI
+
+struct CalendarYearsListView: View {
+    let years: [ChineseLunarYear]
+
+    var body: some View {
+        List {
+            Section("农历年") {
+                ForEach(years, id: \.lunarYearNumber) { year in
+                    NavigationLink(value: CalendarRoute.lunarYear(year.lunarYearNumber)) {
+                        LunarYearRow(year: year)
+                    }
+                }
+            }
+        }
+        .navigationTitle("年份")
+    }
+}

--- a/Sources/ChineseCalendarUI/ChineseDateExpressionSummaryView.swift
+++ b/Sources/ChineseCalendarUI/ChineseDateExpressionSummaryView.swift
@@ -1,0 +1,67 @@
+import ChineseCalendarPersistence
+import SwiftUI
+
+struct ChineseDateExpressionSummaryView: View {
+    let title: String
+    let date: ChineseDateExpression
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(title)
+                .font(.title3)
+                .bold()
+
+            Text(date.sourceText)
+                .font(.headline)
+
+            Text(precisionText)
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+
+            if let note = date.note {
+                Text(note)
+                    .font(.callout)
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding()
+        .background(.background.secondary, in: RoundedRectangle(cornerRadius: 16))
+        .accessibilityElement(children: .combine)
+    }
+
+    private var precisionText: String {
+        switch date.precision {
+        case .year:
+            indexText(prefix: "年精度")
+        case .month:
+            indexText(prefix: "月精度")
+        case .day:
+            indexText(prefix: "日精度")
+        case .range:
+            rangeText
+        case .unknown:
+            "精度未知"
+        }
+    }
+
+    private var rangeText: String {
+        guard let range = date.uncertainRange else {
+            return "范围精度"
+        }
+
+        return "范围精度 · \(boundText(range.lowerBound)) 到 \(boundText(range.upperBound))"
+    }
+
+    private func indexText(prefix: String) -> String {
+        guard let index = date.index else {
+            return prefix
+        }
+
+        return "\(prefix) · index \(index)"
+    }
+
+    private func boundText(_ bound: ChineseDateBound) -> String {
+        "\(bound.precision.rawValue) \(bound.index)"
+    }
+}

--- a/Sources/ChineseCalendarUI/DynastyDetailView.swift
+++ b/Sources/ChineseCalendarUI/DynastyDetailView.swift
@@ -1,0 +1,86 @@
+import ChineseCalendarPersistence
+import SwiftData
+import SwiftUI
+
+struct DynastyDetailView: View {
+    @Query private var dynasties: [Dynasty]
+
+    init(dynastyID: String) {
+        let dynastyID = dynastyID
+        _dynasties = Query(
+            filter: #Predicate<Dynasty> { dynasty in
+                dynasty.id == dynastyID
+            }
+        )
+    }
+
+    var body: some View {
+        if let dynasty {
+            ScrollView {
+                VStack(alignment: .leading, spacing: 24) {
+                    VStack(alignment: .leading, spacing: 8) {
+                        Text(dynasty.name)
+                            .font(.largeTitle)
+                            .bold()
+
+                        if let note = dynasty.note {
+                            Text(note)
+                                .font(.callout)
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+
+                    LazyVGrid(columns: columns, alignment: .leading, spacing: 12) {
+                        DynastyFactCard(title: "皇帝", value: "\(emperors.count) 位")
+                        DynastyFactCard(title: "年号", value: "\(reignEraCount) 个")
+                        DynastyFactCard(title: "短名", value: dynasty.shortName ?? dynasty.name)
+                    }
+
+                    ChineseDateExpressionSummaryView(title: "自称开始", date: dynasty.claimedStartDate)
+                    ChineseDateExpressionSummaryView(title: "自称结束", date: dynasty.claimedEndDate)
+
+                    if !emperors.isEmpty {
+                        VStack(alignment: .leading, spacing: 12) {
+                            Text("皇帝")
+                                .font(.title2)
+                                .bold()
+
+                            ForEach(emperors, id: \.id) { emperor in
+                                EmperorSummaryRow(emperor: emperor)
+                            }
+                        }
+                    }
+                }
+                .padding()
+                .frame(maxWidth: 760, alignment: .leading)
+            }
+            .navigationTitle(dynasty.shortName ?? dynasty.name)
+        } else {
+            ContentUnavailableView {
+                Label("没有找到朝代", systemImage: "building.columns")
+            } description: {
+                Text("这个朝代记录不在当前 SwiftData store 中。")
+            }
+        }
+    }
+
+    private var columns: [GridItem] {
+        [GridItem(.adaptive(minimum: 140), spacing: 12)]
+    }
+
+    private var dynasty: Dynasty? {
+        dynasties.first
+    }
+
+    private var emperors: [Emperor] {
+        dynasty?.emperors.sorted {
+            ($0.sequenceIndex, $0.id) < ($1.sequenceIndex, $1.id)
+        } ?? []
+    }
+
+    private var reignEraCount: Int {
+        emperors.reduce(0) { count, emperor in
+            count + emperor.reignEras.count
+        }
+    }
+}

--- a/Sources/ChineseCalendarUI/DynastyFactCard.swift
+++ b/Sources/ChineseCalendarUI/DynastyFactCard.swift
@@ -1,0 +1,20 @@
+import SwiftUI
+
+struct DynastyFactCard: View {
+    let title: String
+    let value: String
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text(title)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            Text(value)
+                .font(.headline)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding()
+        .background(.background.secondary, in: RoundedRectangle(cornerRadius: 12))
+        .accessibilityElement(children: .combine)
+    }
+}

--- a/Sources/ChineseCalendarUI/EmperorSummaryRow.swift
+++ b/Sources/ChineseCalendarUI/EmperorSummaryRow.swift
@@ -1,0 +1,33 @@
+import ChineseCalendarPersistence
+import SwiftUI
+
+struct EmperorSummaryRow: View {
+    let emperor: Emperor
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(emperor.displayName)
+                .font(.headline)
+
+            Text(subtitle)
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding()
+        .background(.background.secondary, in: RoundedRectangle(cornerRadius: 12))
+        .accessibilityElement(children: .combine)
+    }
+
+    private var subtitle: String {
+        let names = [
+            emperor.personalName,
+            emperor.templeName,
+            emperor.posthumousName
+        ]
+        .compactMap(\.self)
+
+        let nameText = names.isEmpty ? "未记录别名" : names.joined(separator: " · ")
+        return "\(nameText) · \(emperor.reignSegments.count) 段在位 · \(emperor.reignEras.count) 个年号"
+    }
+}

--- a/Sources/ChineseCalendarUI/OrthodoxPeriodRow.swift
+++ b/Sources/ChineseCalendarUI/OrthodoxPeriodRow.swift
@@ -1,0 +1,25 @@
+import ChineseCalendarPersistence
+import SwiftUI
+
+struct OrthodoxPeriodRow: View {
+    let period: OrthodoxPeriod
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(period.dynasty?.name ?? period.segmentName)
+                .font(.headline)
+
+            Text(subtitle)
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+        }
+        .accessibilityElement(children: .combine)
+    }
+
+    private var subtitle: String {
+        let segmentText = period.segmentName
+        let startText = period.startBoundary?.date.sourceText ?? "起点不详"
+        let endText = period.endBoundary?.date.sourceText ?? "终点不详"
+        return "\(segmentText) · \(startText) - \(endText)"
+    }
+}

--- a/Sources/ChineseCalendarUI/Tests/CalendarRouterTests.swift
+++ b/Sources/ChineseCalendarUI/Tests/CalendarRouterTests.swift
@@ -13,6 +13,7 @@ import Testing
 
     #expect(selectedYear == 2025)
     #expect(router.selectedRoute == .lunarYear(2025))
+    #expect(router.yearsPath == [.lunarYear(2025)])
 }
 
 @MainActor
@@ -26,6 +27,30 @@ import Testing
 
     #expect(selectedYear == nil)
     #expect(router.selectedRoute == .lunarYear(2024))
+}
+
+@MainActor
+@Test func pushUpdatesSelectedTabPath() {
+    let router = CalendarRouter()
+
+    router.push(.dynasty("qin"), on: .history)
+
+    #expect(router.selectedTab == .history)
+    #expect(router.historyPath == [.dynasty("qin")])
+    #expect(router.yearsPath.isEmpty)
+}
+
+@MainActor
+@Test func tabPathsDoNotPolluteEachOther() {
+    let router = CalendarRouter()
+
+    router.push(.lunarYear(2025), on: .years)
+    router.push(.dynasty("qin"), on: .history)
+
+    #expect(router.yearsPath == [.lunarYear(2025)])
+    #expect(router.historyPath == [.dynasty("qin")])
+    #expect(router.selectedRoute == .dynasty("qin"))
+    #expect(router.currentRoute(on: .years) == .lunarYear(2025))
 }
 
 @MainActor
@@ -44,10 +69,10 @@ import Testing
     let years = [2024, 2025, 2026]
 
     router.selectPreviousYear(availableYearNumbers: years)
-    #expect(router.selectedRoute == .lunarYear(2024))
+    #expect(router.currentRoute(on: .years) == .lunarYear(2024))
 
     router.selectNextYear(availableYearNumbers: years)
-    #expect(router.selectedRoute == .lunarYear(2025))
+    #expect(router.currentRoute(on: .years) == .lunarYear(2025))
 }
 
 @MainActor
@@ -70,7 +95,7 @@ import Testing
     router.selectYear(2025)
     router.presentSheet(.lunarYear(2025))
 
-    #expect(router.selectedRoute == router.sheet?.route)
+    #expect(router.currentRoute(on: .years) == router.sheet?.route)
 }
 
 @MainActor
@@ -81,7 +106,7 @@ import Testing
     let sheet = router.sheet
     sheet?.push(.lunarYear(2026))
 
-    #expect(router.selectedRoute == nil)
+    #expect(router.yearsPath.isEmpty)
     #expect(sheet?.path == [.lunarYear(2026)])
 }
 
@@ -108,12 +133,12 @@ import Testing
 
     #expect(router.sheet == nil)
     #expect(router.deferredDeepLink == .lunarYear(2026, monthIndex: 26001))
-    #expect(router.selectedRoute == .lunarYear(2024))
+    #expect(router.currentRoute(on: .years) == .lunarYear(2024))
 
     router.applyDeferredDeepLinkIfReady()
 
     #expect(router.deferredDeepLink == nil)
-    #expect(router.selectedRoute == .lunarYear(2026))
+    #expect(router.currentRoute(on: .years) == .lunarYear(2026))
     #expect(router.selectedMonthIndex == 26001)
 }
 
@@ -124,14 +149,31 @@ import Testing
     router.openColdLaunchDeepLink(.lunarYear(2026, monthIndex: 26001))
 
     #expect(router.deferredDeepLink == nil)
-    #expect(router.selectedRoute == .lunarYear(2026))
+    #expect(router.currentRoute(on: .years) == .lunarYear(2026))
     #expect(router.selectedMonthIndex == 26001)
+}
+
+@MainActor
+@Test func dynastyDeepLinkSelectsHistoryTab() {
+    let router = CalendarRouter()
+
+    router.openColdLaunchDeepLink(.dynasty("qin"))
+
+    #expect(router.selectedTab == .history)
+    #expect(router.historyPath == [.dynasty("qin")])
+    #expect(router.selectedMonthIndex == nil)
 }
 
 @Test func parserSupportsYearURLs() throws {
     let url = try #require(URL(string: "chinesecalendar://year/2026?monthIndex=26001"))
 
     #expect(CalendarDeepLinkParser.deepLink(from: url) == .lunarYear(2026, monthIndex: 26001))
+}
+
+@Test func parserSupportsDynastyURLs() throws {
+    let url = try #require(URL(string: "chinesecalendar://dynasty/qin"))
+
+    #expect(CalendarDeepLinkParser.deepLink(from: url) == .dynasty("qin"))
 }
 
 @Test func parserSupportsLaunchArguments() {


### PR DESCRIPTION
## Summary
- refactor CalendarRouter around tab-scoped paths and presentation nodes
- add iOS TabView-based years/history navigation
- add dynasty detail and history timeline surfaces
- extend router tests for tab paths, nested presentation, and deep links

## Validation
- ./Scripts/format.sh --check
- swift test --package-path Sources
- XcodeBuildMCP iOS simulator build