### PR TITLE
Use SFSafeSymbols for app icons

### DIFF
--- a/.agents/skills/cleaning-merged-pr-worktrees/SKILL.md
+++ b/.agents/skills/cleaning-merged-pr-worktrees/SKILL.md
@@ -1,0 +1,105 @@
+---
+name: cleaning-merged-pr-worktrees
+description: Use when cleaning up a local git worktree for a pull request that was already merged, closed, or whose remote branch was deleted
+---
+
+# 清理已合并 PR 的 Worktree
+
+## 概览
+
+只在确认远端 PR 或远端分支已经不再需要本地 worktree 后，才安全删除本地 PR worktree。
+
+**核心原则：** 先确认远端状态 -> 从功能分支 detached 到主分支 -> 删除本地分支 -> 从外部删除 worktree folder。
+
+## 什么时候使用
+
+当用户说类似下面的话时使用：
+
+- “清理这个已经 merge 的 PR worktree”
+- “PR 已经合并了，删除本地 worktree”
+- “远端分支没了，把本地 PR worktree 清掉”
+
+不要用于放弃未合并的工作；那种情况应使用分支完成/丢弃工作流。
+
+## 必要安全检查
+
+以下任一检查失败时，停止删除并询问用户：
+
+| 检查 | 命令 | 停止条件 |
+| --- | --- | --- |
+| worktree 是否干净 | `git status --short` | 有任何输出 |
+| 是否有本地分支 | `git branch --show-current` | 为空但需要删分支 |
+| 远端状态是否明确 | `gh pr view "$BRANCH"` 和 `git ls-remote --heads origin "$BRANCH"` | 无法证明 PR 已合并，也无法证明远端分支已删除 |
+| 远端分支已删但 PR 未确认合并 | `git merge-base --is-ancestor "$BRANCH" "origin/$BASE"` | 本地分支还有未进 base 的提交 |
+
+执行 `gh`、`git fetch` 等网络命令时，遵守当前会话的网络和代理规则。
+
+## 流程
+
+### 1. 记录状态，并确认远端可以安全清理
+
+```bash
+WORKTREE_PATH=$(git rev-parse --show-toplevel)
+BRANCH=$(git branch --show-current)
+GIT_COMMON=$(cd "$(git rev-parse --git-common-dir)" 2>/dev/null && pwd -P)
+MAIN_ROOT=$(git -C "$GIT_COMMON/.." rev-parse --show-toplevel)
+BASE=${BASE:-master}
+
+git status --short
+git fetch --prune origin
+gh pr view "$BRANCH" --json state,mergedAt,headRefName,baseRefName
+git ls-remote --heads origin "$BRANCH"
+```
+
+只有在证明以下任一条件成立时继续：
+
+- PR 存在，并且 `mergedAt` 不是 `null`。
+- 远端分支已删除，并且 `git merge-base --is-ancestor "$BRANCH" "origin/$BASE"` 成功。
+
+如果 PR 只是关闭但未合并，或者远端分支已删除但本地分支还有未进入 base 的提交，停止并询问用户。
+
+### 2. 从功能分支 detached 到主分支，并删除本地分支
+
+这一步必须在 worktree folder 还存在时执行：
+
+```bash
+git -C "$WORKTREE_PATH" switch --detach "origin/$BASE"
+git -C "$WORKTREE_PATH" branch -d "$BRANCH"
+```
+
+如果 `branch -d` 因为 squash merge 失败，只有在前面已经确认 PR 已合并时，才使用强制删除：
+
+```bash
+git -C "$WORKTREE_PATH" branch -D "$BRANCH"
+```
+
+### 3. 从 worktree 外部删除 worktree folder
+
+不要在即将删除的 worktree 内执行 `git worktree remove`。
+
+```bash
+cd "$MAIN_ROOT"
+git worktree remove "$WORKTREE_PATH"
+git worktree prune
+git worktree list
+```
+
+如果 `git worktree remove` 提示该路径不是已注册 worktree，必须先得到用户明确确认，才能使用 `rm -rf`。
+
+## 快速参考
+
+| 情况 | 动作 |
+| --- | --- |
+| PR 已合并 | detached、删除本地分支、删除 worktree |
+| 远端分支已删除，且本地分支是 base 的祖先 | detached、删除本地分支、删除 worktree |
+| 远端分支已删除，但本地分支还有独有提交 | 停止并询问 |
+| worktree 有未提交改动 | 停止并询问 |
+| 当前 shell 在要删除的 worktree 内 | 先 detached，再从 `MAIN_ROOT` 删除 |
+
+## 常见错误
+
+- 还在功能分支上时就删除本地分支。
+- 先删除 folder，再删除分支。
+- 把“远端分支已删除”当成“PR 已合并”的证明。
+- 在要删除的 worktree 内执行 `git worktree remove`。
+- 未证明 PR 已合并或分支已进入 base 就使用 `branch -D`。

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -12,6 +12,13 @@ excluded:
 analyzer_rules:
   - unused_import
 
+custom_rules:
+  sf_safe_symbols:
+    name: "Safe SF Symbols"
+    message: "Use SFSafeSymbols via systemSymbol instead of raw SF Symbol strings."
+    regex: "(systemImage:|systemName:|UIImage\\(systemName:|NSImage\\(systemSymbolName:)"
+    severity: warning
+
 opt_in_rules:
   - empty_count
   - explicit_init

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,6 +57,7 @@ This repository hosts a Swift project for browsing the traditional Chinese calen
 - Project-local skill: `./.agents/skills/publish-full-seed-store`
 - Project-local skill: `./.agents/skills/worktree-setup`
 - Project-local skill: `./.agents/skills/worktree-cleanup`
+- Project-local skill: `./.agents/skills/cleaning-merged-pr-worktrees`
 
 ## Apple Documentation
 
@@ -87,3 +88,4 @@ When a task is primarily about async/await, actor isolation, cancellation, or ta
 When a task is primarily about SwiftData models, predicates, indexing, or CloudKit integration, prefer `swiftdata-pro`.
 When publishing a new remote full SwiftData seed store SQLite release, prefer `publish-full-seed-store`.
 When setting up or cleaning up branch worktrees, prefer `worktree-setup` or `worktree-cleanup`.
+When cleaning up a local worktree for a PR that was already merged, closed, or whose remote branch was deleted, prefer `cleaning-merged-pr-worktrees`.

--- a/Scripts/BuildChineseCalendarSeedStore/Package.swift
+++ b/Scripts/BuildChineseCalendarSeedStore/Package.swift
@@ -1,5 +1,10 @@
-// swift-tools-version: 6.2
+// swift-tools-version: 6.3
 import PackageDescription
+
+let nonisolatedSwiftSettings: [SwiftSetting] = [
+    .swiftLanguageMode(.v6),
+    .defaultIsolation(nil)
+]
 
 let package = Package(
     name: "BuildChineseCalendarSeedStore",
@@ -21,7 +26,8 @@ let package = Package(
             dependencies: [
                 .product(name: "ChineseCalendarCore", package: "Sources"),
                 .product(name: "ChineseCalendarPersistence", package: "Sources")
-            ]
+            ],
+            swiftSettings: nonisolatedSwiftSettings
         )
     ]
 )

--- a/Sources/ChineseCalendarUI/CalendarHistoryHomeView.swift
+++ b/Sources/ChineseCalendarUI/CalendarHistoryHomeView.swift
@@ -1,4 +1,5 @@
 import ChineseCalendarPersistence
+import SFSafeSymbols
 import SwiftData
 import SwiftUI
 
@@ -9,9 +10,12 @@ struct CalendarHistoryHomeView: View {
         List {
             if periods.isEmpty {
                 ContentUnavailableView(
-                    "没有历史时间线数据",
-                    systemImage: "timeline.selection",
-                    description: Text("当前 SwiftData store 中没有可显示的正统时期。")
+                    label: {
+                        Label("没有历史时间线数据", systemSymbol: .timelineSelection)
+                    },
+                    description: {
+                        Text("当前 SwiftData store 中没有可显示的正统时期。")
+                    }
                 )
             } else {
                 Section("主流中国王朝序列") {

--- a/Sources/ChineseCalendarUI/CalendarHomeTabView.swift
+++ b/Sources/ChineseCalendarUI/CalendarHomeTabView.swift
@@ -1,4 +1,5 @@
 import ChineseCalendarPersistence
+import SFSafeSymbols
 import SwiftUI
 
 struct CalendarHomeTabView: View {
@@ -15,7 +16,7 @@ struct CalendarHomeTabView: View {
                     .toolbar(content: settingsToolbar)
             }
             .tabItem {
-                Label(CalendarTab.years.title, systemImage: CalendarTab.years.systemImage)
+                Label(CalendarTab.years.title, systemSymbol: CalendarTab.years.systemSymbol)
             }
             .tag(CalendarTab.years)
 
@@ -25,7 +26,7 @@ struct CalendarHomeTabView: View {
                     .toolbar(content: settingsToolbar)
             }
             .tabItem {
-                Label(CalendarTab.history.title, systemImage: CalendarTab.history.systemImage)
+                Label(CalendarTab.history.title, systemSymbol: CalendarTab.history.systemSymbol)
             }
             .tag(CalendarTab.history)
         }
@@ -35,7 +36,7 @@ struct CalendarHomeTabView: View {
     private func settingsToolbar() -> some ToolbarContent {
         if let openSettings {
             ToolbarItem(placement: .primaryAction) {
-                Button("设置", systemImage: "gearshape", action: openSettings)
+                Button("设置", systemSymbol: .gearshape, action: openSettings)
             }
         }
     }

--- a/Sources/ChineseCalendarUI/CalendarRouteDestinationView.swift
+++ b/Sources/ChineseCalendarUI/CalendarRouteDestinationView.swift
@@ -1,4 +1,5 @@
 import ChineseCalendarPersistence
+import SFSafeSymbols
 import SwiftUI
 
 struct CalendarRouteDestinationView: View {
@@ -46,7 +47,7 @@ struct CalendarRouteDestinationView: View {
                     )
                 } else {
                     ContentUnavailableView {
-                        Label("Chinese Calendar", systemImage: "calendar.badge.exclamationmark")
+                        Label("Chinese Calendar", systemSymbol: .calendarBadgeExclamationmark)
                     } description: {
                         Text("没有找到这个农历年。")
                     }
@@ -55,7 +56,7 @@ struct CalendarRouteDestinationView: View {
                 DynastyDetailView(dynastyID: dynastyID)
             case nil:
                 ContentUnavailableView {
-                    Label("Chinese Calendar", systemImage: "calendar")
+                    Label("Chinese Calendar", systemSymbol: .calendar)
                 } description: {
                     Text(emptyStateDescription)
                 }

--- a/Sources/ChineseCalendarUI/CalendarSettingsView.swift
+++ b/Sources/ChineseCalendarUI/CalendarSettingsView.swift
@@ -1,4 +1,5 @@
 import ChineseCalendarPersistence
+import SFSafeSymbols
 import SwiftUI
 
 public struct CalendarSettingsView: View {
@@ -16,7 +17,7 @@ public struct CalendarSettingsView: View {
         Form {
             Section("数据") {
                 VStack(alignment: .leading, spacing: 6) {
-                    Label(dataStatusTitle, systemImage: dataStatusSystemImage)
+                    Label(dataStatusTitle, systemSymbol: dataStatusSystemSymbol)
                         .font(.headline)
                     Text(dataStatusDetail)
                         .font(.callout)
@@ -34,7 +35,7 @@ public struct CalendarSettingsView: View {
                             ProgressView()
                         }
                     } else {
-                        Label("清空已下载数据", systemImage: "trash")
+                        Label("清空已下载数据", systemSymbol: .trash)
                     }
                 }
                 .disabled(coordinator.isClearingDownloadedData)
@@ -113,20 +114,20 @@ public struct CalendarSettingsView: View {
         }
     }
 
-    private var dataStatusSystemImage: String {
+    private var dataStatusSystemSymbol: SFSymbol {
         if coordinator.fullStoreDownloadProgress != nil {
-            return "arrow.down.circle"
+            return .arrowDownCircle
         }
 
         switch coordinator.state {
         case .ready(_, .full, _):
-            return "externaldrive.fill"
+            return .externaldriveFill
         case .ready:
-            return "externaldrive"
+            return .externaldrive
         case .starting:
-            return "hourglass"
+            return .hourglass
         case .failed:
-            return "externaldrive.badge.exclamationmark"
+            return .externaldriveBadgeExclamationmark
         }
     }
 

--- a/Sources/ChineseCalendarUI/CalendarTab.swift
+++ b/Sources/ChineseCalendarUI/CalendarTab.swift
@@ -1,4 +1,5 @@
 import Foundation
+import SFSafeSymbols
 
 enum CalendarTab: Hashable, CaseIterable, Identifiable {
     case years
@@ -17,12 +18,12 @@ enum CalendarTab: Hashable, CaseIterable, Identifiable {
         }
     }
 
-    var systemImage: String {
+    var systemSymbol: SFSymbol {
         switch self {
         case .years:
-            "calendar"
+            .calendar
         case .history:
-            "timeline.selection"
+            .timelineSelection
         }
     }
 }

--- a/Sources/ChineseCalendarUI/ChineseCalendarRootView.swift
+++ b/Sources/ChineseCalendarUI/ChineseCalendarRootView.swift
@@ -1,4 +1,5 @@
 import ChineseCalendarPersistence
+import SFSafeSymbols
 import SwiftData
 import SwiftUI
 
@@ -98,12 +99,12 @@ private struct FullStoreDownloadBanner: View {
 
     var body: some View {
         HStack(spacing: 12) {
-            Label("可下载完整日期数据", systemImage: "arrow.down.circle")
+            Label("可下载完整日期数据", systemSymbol: .arrowDownCircle)
                 .font(.callout)
 
             Spacer(minLength: 12)
 
-            Button("下载", systemImage: "arrow.down", action: action)
+            Button("下载", systemSymbol: .arrowDown, action: action)
                 .buttonStyle(.borderedProminent)
         }
         .padding(.horizontal)
@@ -142,11 +143,11 @@ private struct CalendarStoreFailureView: View {
 
     var body: some View {
         ContentUnavailableView {
-            Label("无法打开日历数据", systemImage: "externaldrive.badge.exclamationmark")
+            Label("无法打开日历数据", systemSymbol: .externaldriveBadgeExclamationmark)
         } description: {
             Text(message)
         } actions: {
-            Button("重试", systemImage: "arrow.clockwise", action: retry)
+            Button("重试", systemSymbol: .arrowClockwise, action: retry)
         }
     }
 }

--- a/Sources/ChineseCalendarUI/DynastyDetailView.swift
+++ b/Sources/ChineseCalendarUI/DynastyDetailView.swift
@@ -1,4 +1,5 @@
 import ChineseCalendarPersistence
+import SFSafeSymbols
 import SwiftData
 import SwiftUI
 
@@ -57,7 +58,7 @@ struct DynastyDetailView: View {
             .navigationTitle(dynasty.shortName ?? dynasty.name)
         } else {
             ContentUnavailableView {
-                Label("没有找到朝代", systemImage: "building.columns")
+                Label("没有找到朝代", systemSymbol: .buildingColumns)
             } description: {
                 Text("这个朝代记录不在当前 SwiftData store 中。")
             }

--- a/Sources/ChineseCalendarUI/FullStoreDownloadProgress.swift
+++ b/Sources/ChineseCalendarUI/FullStoreDownloadProgress.swift
@@ -1,4 +1,5 @@
 import Foundation
+import SFSafeSymbols
 
 enum FullStoreDownloadPhase: Equatable {
     case preparingManifest
@@ -70,18 +71,18 @@ struct FullStoreDownloadProgress: Equatable {
         }
     }
 
-    var systemImage: String {
+    var systemSymbol: SFSymbol {
         switch phase {
         case .preparingManifest:
-            "doc.text.magnifyingglass"
+            .textPageBadgeMagnifyingglass
         case .downloading:
-            "arrow.down.circle"
+            .arrowDownCircle
         case .validating:
-            "checkmark.shield"
+            .checkmarkShield
         case .installing:
-            "externaldrive.badge.checkmark"
+            .externaldriveBadgeCheckmark
         case .completed:
-            "checkmark.circle.fill"
+            .checkmarkCircleFill
         }
     }
 

--- a/Sources/ChineseCalendarUI/FullStoreDownloadProgressViews.swift
+++ b/Sources/ChineseCalendarUI/FullStoreDownloadProgressViews.swift
@@ -1,3 +1,4 @@
+import SFSafeSymbols
 import SwiftUI
 
 public struct FullStoreDownloadProgressWindow: View {
@@ -16,9 +17,12 @@ public struct FullStoreDownloadProgressWindow: View {
                     .padding(20)
             } else {
                 ContentUnavailableView(
-                    "没有正在下载的数据",
-                    systemImage: "checkmark.circle",
-                    description: Text("开始下载完整日期数据后，进度会显示在这里。")
+                    label: {
+                        Label("没有正在下载的数据", systemSymbol: .checkmarkCircle)
+                    },
+                    description: {
+                        Text("开始下载完整日期数据后，进度会显示在这里。")
+                    }
                 )
                 .padding()
             }
@@ -40,7 +44,7 @@ struct FullStoreDownloadBottomProgressView: View {
         } label: {
             VStack(alignment: .leading, spacing: 10) {
                 HStack(spacing: 10) {
-                    Image(systemName: progress.systemImage)
+                    Image(systemSymbol: progress.systemSymbol)
                         .font(.title3)
                         .foregroundStyle(.tint)
                         .frame(width: 24)
@@ -55,7 +59,7 @@ struct FullStoreDownloadBottomProgressView: View {
                         .font(.footnote.monospacedDigit())
                         .foregroundStyle(.secondary)
 
-                    Image(systemName: "chevron.up")
+                    Image(systemSymbol: .chevronUp)
                         .font(.caption.weight(.semibold))
                         .foregroundStyle(.secondary)
                         .rotationEffect(isExpanded ? .zero : .degrees(180))
@@ -87,7 +91,7 @@ struct FullStoreDownloadMacStatusBar: View {
 
     var body: some View {
         HStack(spacing: 12) {
-            Label(progress.title, systemImage: progress.systemImage)
+            Label(progress.title, systemSymbol: progress.systemSymbol)
                 .font(.callout)
 
             ProgressView(value: progress.fractionCompleted)
@@ -99,7 +103,7 @@ struct FullStoreDownloadMacStatusBar: View {
 
             Spacer(minLength: 12)
 
-            Button("查看进度", systemImage: "arrow.up.forward.app", action: openProgressWindow)
+            Button("查看进度", systemSymbol: .arrowUpForwardApp, action: openProgressWindow)
                 .buttonStyle(.bordered)
         }
         .padding(.horizontal)
@@ -114,7 +118,7 @@ private struct FullStoreDownloadProgressContent: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 16) {
-            Label(progress.title, systemImage: progress.systemImage)
+            Label(progress.title, systemSymbol: progress.systemSymbol)
                 .font(.headline)
 
             VStack(alignment: .leading, spacing: 8) {

--- a/Sources/ChineseCalendarUI/LunarMonthGrid.swift
+++ b/Sources/ChineseCalendarUI/LunarMonthGrid.swift
@@ -1,5 +1,6 @@
 import ChineseCalendarCore
 import ChineseCalendarPersistence
+import SFSafeSymbols
 import SwiftData
 import SwiftUI
 
@@ -32,9 +33,12 @@ struct LunarMonthGrid: View {
 
             if periods.isEmpty {
                 ContentUnavailableView(
-                    emptyStateTitle,
-                    systemImage: emptyStateSystemImage,
-                    description: Text(emptyStateDescription)
+                    label: {
+                        Label(emptyStateTitle, systemSymbol: emptyStateSystemSymbol)
+                    },
+                    description: {
+                        Text(emptyStateDescription)
+                    }
                 )
                 .frame(maxWidth: .infinity, alignment: .leading)
             } else {
@@ -59,12 +63,12 @@ struct LunarMonthGrid: View {
         }
     }
 
-    private var emptyStateSystemImage: String {
+    private var emptyStateSystemSymbol: SFSymbol {
         switch storeContentLevel {
         case .base:
-            "arrow.down.circle"
+            .arrowDownCircle
         case .full:
-            "calendar.badge.exclamationmark"
+            .calendarBadgeExclamationmark
         }
     }
 

--- a/Sources/ChineseCalendarUI/LunarYearDetailView.swift
+++ b/Sources/ChineseCalendarUI/LunarYearDetailView.swift
@@ -1,5 +1,6 @@
 import ChineseCalendarCore
 import ChineseCalendarPersistence
+import SFSafeSymbols
 import SwiftData
 import SwiftUI
 
@@ -58,7 +59,9 @@ struct LunarYearDetailView: View {
                     .foregroundStyle(.secondary)
 
                 if monthsInYearStartOrder.isEmpty {
-                    ContentUnavailableView("没有月份数据", systemImage: "calendar.badge.exclamationmark")
+                    ContentUnavailableView {
+                        Label("没有月份数据", systemSymbol: .calendarBadgeExclamationmark)
+                    }
                 } else if let selectedMonth {
                     MonthSwitcher(
                         months: monthsInYearStartOrder,
@@ -79,11 +82,11 @@ struct LunarYearDetailView: View {
         .navigationTitle(LunarCalendarFormatting.yearTitle(lunarYearNumber: year.lunarYearNumber))
         .toolbar {
             ToolbarItemGroup(placement: .primaryAction) {
-                Button("上一年", systemImage: "chevron.left", action: selectPreviousYear)
+                Button("上一年", systemSymbol: .chevronLeft, action: selectPreviousYear)
                     .disabled(!canSelectPreviousYear)
                     .help("切换到上一年")
 
-                Button("下一年", systemImage: "chevron.right", action: selectNextYear)
+                Button("下一年", systemSymbol: .chevronRight, action: selectNextYear)
                     .disabled(!canSelectNextYear)
                     .help("切换到下一年")
             }

--- a/Sources/ChineseCalendarUI/MonthSwitcher.swift
+++ b/Sources/ChineseCalendarUI/MonthSwitcher.swift
@@ -1,5 +1,6 @@
 import ChineseCalendarCore
 import ChineseCalendarPersistence
+import SFSafeSymbols
 import SwiftUI
 
 struct MonthSwitcher: View {
@@ -30,7 +31,7 @@ struct MonthSwitcher: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {
             HStack(spacing: 12) {
-                Button("上个月", systemImage: "chevron.left", action: selectPreviousMonth)
+                Button("上个月", systemSymbol: .chevronLeft, action: selectPreviousMonth)
                     .labelStyle(.iconOnly)
                     .disabled(!canSelectPreviousMonth)
                     .help("切换到上个月")
@@ -49,7 +50,7 @@ struct MonthSwitcher: View {
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .accessibilityElement(children: .combine)
 
-                Button("下个月", systemImage: "chevron.right", action: selectNextMonth)
+                Button("下个月", systemSymbol: .chevronRight, action: selectNextMonth)
                     .labelStyle(.iconOnly)
                     .disabled(!canSelectNextMonth)
                     .help("切换到下个月")

--- a/Sources/Package.swift
+++ b/Sources/Package.swift
@@ -1,5 +1,15 @@
-// swift-tools-version: 6.2
+// swift-tools-version: 6.3
 import PackageDescription
+
+let nonisolatedSwiftSettings: [SwiftSetting] = [
+    .swiftLanguageMode(.v6),
+    .defaultIsolation(nil)
+]
+
+let mainActorSwiftSettings: [SwiftSetting] = [
+    .swiftLanguageMode(.v6),
+    .defaultIsolation(MainActor.self)
+]
 
 let package = Package(
     name: "ChineseCalendarSources",
@@ -30,17 +40,22 @@ let package = Package(
             targets: ["ChineseCalendarUI"]
         )
     ],
+    dependencies: [
+        .package(url: "https://github.com/SFSafeSymbols/SFSafeSymbols.git", .upToNextMajor(from: "7.0.0"))
+    ],
     targets: [
         .target(
             name: "ChineseCalendarLogging",
             path: "ChineseCalendarLogging",
-            exclude: ["README.md", "Tests"]
+            exclude: ["README.md", "Tests"],
+            swiftSettings: nonisolatedSwiftSettings
         ),
         .target(
             name: "ChineseCalendarCore",
             dependencies: ["ChineseCalendarLogging"],
             path: "ChineseCalendarCore",
-            exclude: ["Tests"]
+            exclude: ["Tests"],
+            swiftSettings: nonisolatedSwiftSettings
         ),
         .target(
             name: "ChineseCalendarData",
@@ -49,7 +64,8 @@ let package = Package(
                 "ChineseCalendarLogging"
             ],
             path: "ChineseCalendarData",
-            exclude: ["Tests"]
+            exclude: ["Tests"],
+            swiftSettings: nonisolatedSwiftSettings
         ),
         .target(
             name: "ChineseCalendarPersistence",
@@ -58,7 +74,8 @@ let package = Package(
                 "ChineseCalendarData",
                 "ChineseCalendarLogging"
             ],
-            path: "ChineseCalendarPersistence"
+            path: "ChineseCalendarPersistence",
+            swiftSettings: nonisolatedSwiftSettings
         ),
         .target(
             name: "ChineseCalendarUI",
@@ -66,30 +83,36 @@ let package = Package(
                 "ChineseCalendarCore",
                 "ChineseCalendarData",
                 "ChineseCalendarPersistence",
-                "ChineseCalendarLogging"
+                "ChineseCalendarLogging",
+                .product(name: "SFSafeSymbols", package: "SFSafeSymbols")
             ],
             path: "ChineseCalendarUI",
-            exclude: ["Tests"]
+            exclude: ["Tests"],
+            swiftSettings: mainActorSwiftSettings
         ),
         .testTarget(
             name: "ChineseCalendarCoreTests",
             dependencies: ["ChineseCalendarCore"],
-            path: "ChineseCalendarCore/Tests"
+            path: "ChineseCalendarCore/Tests",
+            swiftSettings: nonisolatedSwiftSettings
         ),
         .testTarget(
             name: "ChineseCalendarDataTests",
             dependencies: ["ChineseCalendarCore", "ChineseCalendarData"],
-            path: "ChineseCalendarData/Tests"
+            path: "ChineseCalendarData/Tests",
+            swiftSettings: nonisolatedSwiftSettings
         ),
         .testTarget(
             name: "ChineseCalendarLoggingTests",
             dependencies: ["ChineseCalendarLogging"],
-            path: "ChineseCalendarLogging/Tests"
+            path: "ChineseCalendarLogging/Tests",
+            swiftSettings: nonisolatedSwiftSettings
         ),
         .testTarget(
             name: "ChineseCalendarUITests",
             dependencies: ["ChineseCalendarUI"],
-            path: "ChineseCalendarUI/Tests"
+            path: "ChineseCalendarUI/Tests",
+            swiftSettings: mainActorSwiftSettings
         )
     ]
 )

--- a/project.yml
+++ b/project.yml
@@ -61,6 +61,7 @@ targets:
         SUPPORTS_MACCATALYST: NO
         SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD: NO
         SWIFT_VERSION: 6.0
+        SWIFT_DEFAULT_ACTOR_ISOLATION: MainActor
         CODE_SIGN_STYLE: Automatic
         DEVELOPMENT_TEAM: F29WG8477A
         CODE_SIGN_ENTITLEMENTS: Apps/iOSApp/ChineseCalendar-iOS.entitlements
@@ -118,6 +119,7 @@ targets:
         PRODUCT_NAME: Chinese Calendar
         PRODUCT_BUNDLE_IDENTIFIER: com.tiger.suzhou.ChineseCalendar
         SWIFT_VERSION: 6.0
+        SWIFT_DEFAULT_ACTOR_ISOLATION: MainActor
         CODE_SIGN_STYLE: Automatic
         DEVELOPMENT_TEAM: F29WG8477A
         CODE_SIGN_ENTITLEMENTS: Apps/macOSApp/ChineseCalendar-macOS.entitlements


### PR DESCRIPTION
## Summary
- Add SFSafeSymbols 7.0.0 to the shared package and switch SwiftUI icon calls to `systemSymbol:`.
- Update package tools versions to Swift 6.3 and configure default actor isolation for package/app targets.
- Add a SwiftLint custom rule to prevent raw SF Symbol string usage from returning.

## Validation
- `swift test --package-path Sources`
- `swift build --package-path Scripts/BuildChineseCalendarSeedStore`
- `swiftlint lint --quiet`
- XcodeBuildMCP iOS simulator build (`-skipPackageUpdates -onlyUsePackageVersionsFromResolvedFile`)