### PR TITLE
Redesign iOS calendar tabs

### DIFF
--- a/Scripts/fix_xcodegen_local_package_backlinks.py
+++ b/Scripts/fix_xcodegen_local_package_backlinks.py
@@ -21,6 +21,14 @@ from pathlib import Path
 
 PBXPROJ = Path("ChineseCalendar.xcodeproj/project.pbxproj")
 PROJECT_YML = Path("project.yml")
+IOS_SCHEME = Path("ChineseCalendar.xcodeproj/xcshareddata/xcschemes/ChineseCalendar-iOS.xcscheme")
+PACKAGE_CONTAINER = "container:Sources"
+IOS_TEST_TARGETS = [
+    "ChineseCalendarCoreTests",
+    "ChineseCalendarDataTests",
+    "ChineseCalendarLoggingTests",
+    "ChineseCalendarUITests",
+]
 
 
 @dataclass(frozen=True)
@@ -243,6 +251,62 @@ def patch_product_dependencies(
     return output, changed, unresolved
 
 
+def testable_reference(target_name: str) -> list[str]:
+    return [
+        '          <TestableReference',
+        '             skipped = "NO">',
+        '             <BuildableReference',
+        '                BuildableIdentifier = "primary"',
+        f'                BlueprintIdentifier = "{target_name}"',
+        f'                BuildableName = "{target_name}"',
+        f'                BlueprintName = "{target_name}"',
+        f'                ReferencedContainer = "{PACKAGE_CONTAINER}">',
+        '             </BuildableReference>',
+        '          </TestableReference>',
+    ]
+
+
+def patch_ios_scheme_testables(path: Path) -> bool:
+    if not path.exists():
+        print(f"warning: {path} does not exist; skipping iOS scheme testables", file=sys.stderr)
+        return False
+
+    original_text = path.read_text()
+    if all(f'BlueprintName = "{target}"' in original_text for target in IOS_TEST_TARGETS):
+        return False
+
+    lines = original_text.splitlines()
+    output: list[str] = []
+    index = 0
+    patched = False
+
+    while index < len(lines):
+        output.append(lines[index])
+        if lines[index].strip() != "<Testables>":
+            index += 1
+            continue
+
+        index += 1
+        while index < len(lines) and lines[index].strip() != "</Testables>":
+            index += 1
+
+        for target_name in IOS_TEST_TARGETS:
+            output.extend(testable_reference(target_name))
+
+        if index < len(lines):
+            output.append(lines[index])
+        patched = True
+        index += 1
+
+    if not patched:
+        print(f"warning: no Testables section found in {path}", file=sys.stderr)
+        return False
+
+    trailing_newline = "\n" if original_text.endswith("\n") else ""
+    path.write_text("\n".join(output) + trailing_newline)
+    return True
+
+
 def main() -> int:
     pbxproj = Path(sys.argv[1]) if len(sys.argv) > 1 else PBXPROJ
     if not pbxproj.exists():
@@ -267,13 +331,20 @@ def main() -> int:
         print(f"error: could not resolve local package for product(s): {names}", file=sys.stderr)
         return 1
 
-    if changed == 0:
-        print("Local Swift package backlinks already present.")
-        return 0
+    scheme_changed = patch_ios_scheme_testables(IOS_SCHEME)
 
     trailing_newline = "\n" if original_text.endswith("\n") else ""
-    pbxproj.write_text("\n".join(patched_lines) + trailing_newline)
-    print(f"Patched {changed} local Swift package product backlink(s).")
+    if changed > 0:
+        pbxproj.write_text("\n".join(patched_lines) + trailing_newline)
+
+    if changed == 0 and not scheme_changed:
+        print("Local Swift package backlinks and iOS scheme testables already present.")
+        return 0
+
+    if changed > 0:
+        print(f"Patched {changed} local Swift package product backlink(s).")
+    if scheme_changed:
+        print("Patched ChineseCalendar-iOS scheme package testables.")
     return 0
 
 

--- a/Sources/ChineseCalendarUI/CalendarFactTile.swift
+++ b/Sources/ChineseCalendarUI/CalendarFactTile.swift
@@ -1,0 +1,20 @@
+import SwiftUI
+
+struct CalendarFactTile: View {
+    let title: String
+    let value: String
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text(title)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            Text(value)
+                .font(.headline)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding()
+        .background(.background, in: RoundedRectangle(cornerRadius: 18))
+        .accessibilityElement(children: .combine)
+    }
+}

--- a/Sources/ChineseCalendarUI/CalendarHistoryHomeView.swift
+++ b/Sources/ChineseCalendarUI/CalendarHistoryHomeView.swift
@@ -7,30 +7,59 @@ struct CalendarHistoryHomeView: View {
     @Query(sort: \OrthodoxPeriod.sequenceIndex) private var periods: [OrthodoxPeriod]
 
     var body: some View {
-        List {
-            if periods.isEmpty {
-                ContentUnavailableView(
-                    label: {
-                        Label("没有历史时间线数据", systemSymbol: .timelineSelection)
-                    },
-                    description: {
-                        Text("当前 SwiftData store 中没有可显示的正统时期。")
-                    }
-                )
-            } else {
-                Section("主流中国王朝序列") {
-                    ForEach(periods, id: \.id) { period in
-                        if let dynastyID = period.dynasty?.id {
-                            NavigationLink(value: CalendarRoute.dynasty(dynastyID)) {
-                                OrthodoxPeriodRow(period: period)
-                            }
-                        } else {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 16) {
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("历史")
+                        .font(.caption)
+                        .bold()
+                        .foregroundStyle(.tint)
+                    Text("正统时间线")
+                        .font(.largeTitle)
+                        .bold()
+                    Text("按朝代顺序浏览政治时间线，列表中直接显示皇帝数和年号数。")
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                }
+                .padding()
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .background(.background.secondary, in: RoundedRectangle(cornerRadius: 28))
+
+                content
+            }
+            .padding()
+            .frame(maxWidth: 760, alignment: .leading)
+        }
+        .navigationTitle("历史")
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        if periods.isEmpty {
+            ContentUnavailableView(
+                label: {
+                    Label("没有历史时间线数据", systemSymbol: .timelineSelection)
+                },
+                description: {
+                    Text("当前 SwiftData store 中没有可显示的正统时期。")
+                }
+            )
+            .padding()
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(.background.secondary, in: RoundedRectangle(cornerRadius: 28))
+        } else {
+            LazyVStack(alignment: .leading, spacing: 12) {
+                ForEach(periods, id: \.id) { period in
+                    if let dynastyID = period.dynasty?.id {
+                        NavigationLink(value: CalendarRoute.dynasty(dynastyID)) {
                             OrthodoxPeriodRow(period: period)
                         }
+                        .buttonStyle(.plain)
+                    } else {
+                        OrthodoxPeriodRow(period: period)
                     }
                 }
             }
         }
-        .navigationTitle("历史")
     }
 }

--- a/Sources/ChineseCalendarUI/CalendarHomeSplitView.swift
+++ b/Sources/ChineseCalendarUI/CalendarHomeSplitView.swift
@@ -26,6 +26,7 @@ struct CalendarHomeSplitView: View {
                 canSelectNextYear: router.canSelectNextYear(availableYearNumbers: yearNumbers),
                 selectPreviousYear: { router.selectPreviousYear(availableYearNumbers: yearNumbers) },
                 selectNextYear: { router.selectNextYear(availableYearNumbers: yearNumbers) },
+                showYearList: nil,
                 emptyStateDescription: emptyStateDescription
             )
         }

--- a/Sources/ChineseCalendarUI/CalendarHomeTabView.swift
+++ b/Sources/ChineseCalendarUI/CalendarHomeTabView.swift
@@ -2,11 +2,12 @@ import ChineseCalendarPersistence
 import SFSafeSymbols
 import SwiftUI
 
-struct CalendarHomeTabView: View {
+struct CalendarHomeTabView<BottomStatusBar: View>: View {
     @Bindable var router: CalendarRouter
     let years: [ChineseLunarYear]
     let emptyStateDescription: String
     let settingsCoordinator: ChineseCalendarStoreCoordinator?
+    let bottomStatusBar: () -> BottomStatusBar
 
     var body: some View {
         TabView(selection: $router.selectedTab) {
@@ -14,6 +15,7 @@ struct CalendarHomeTabView: View {
                 CalendarYearsListView(years: years)
                     .navigationDestination(for: CalendarRoute.self, destination: destination)
             }
+            .safeAreaInset(edge: .bottom, spacing: 0, content: bottomStatusBar)
             .tabItem {
                 Label(CalendarTab.years.title, systemSymbol: CalendarTab.years.systemSymbol)
             }
@@ -23,6 +25,7 @@ struct CalendarHomeTabView: View {
                 CalendarHistoryHomeView()
                     .navigationDestination(for: CalendarRoute.self, destination: destination)
             }
+            .safeAreaInset(edge: .bottom, spacing: 0, content: bottomStatusBar)
             .tabItem {
                 Label(CalendarTab.history.title, systemSymbol: CalendarTab.history.systemSymbol)
             }
@@ -39,6 +42,7 @@ struct CalendarHomeTabView: View {
                     }
                 }
             }
+            .safeAreaInset(edge: .bottom, spacing: 0, content: bottomStatusBar)
             .tabItem {
                 Label(CalendarTab.settings.title, systemSymbol: CalendarTab.settings.systemSymbol)
             }

--- a/Sources/ChineseCalendarUI/CalendarHomeTabView.swift
+++ b/Sources/ChineseCalendarUI/CalendarHomeTabView.swift
@@ -6,14 +6,13 @@ struct CalendarHomeTabView: View {
     @Bindable var router: CalendarRouter
     let years: [ChineseLunarYear]
     let emptyStateDescription: String
-    let openSettings: (() -> Void)?
+    let settingsCoordinator: ChineseCalendarStoreCoordinator?
 
     var body: some View {
         TabView(selection: $router.selectedTab) {
             NavigationStack(path: $router.yearsPath) {
                 CalendarYearsListView(years: years)
                     .navigationDestination(for: CalendarRoute.self, destination: destination)
-                    .toolbar(content: settingsToolbar)
             }
             .tabItem {
                 Label(CalendarTab.years.title, systemSymbol: CalendarTab.years.systemSymbol)
@@ -23,21 +22,27 @@ struct CalendarHomeTabView: View {
             NavigationStack(path: $router.historyPath) {
                 CalendarHistoryHomeView()
                     .navigationDestination(for: CalendarRoute.self, destination: destination)
-                    .toolbar(content: settingsToolbar)
             }
             .tabItem {
                 Label(CalendarTab.history.title, systemSymbol: CalendarTab.history.systemSymbol)
             }
             .tag(CalendarTab.history)
-        }
-    }
 
-    @ToolbarContentBuilder
-    private func settingsToolbar() -> some ToolbarContent {
-        if let openSettings {
-            ToolbarItem(placement: .primaryAction) {
-                Button("设置", systemSymbol: .gearshape, action: openSettings)
+            NavigationStack {
+                if let settingsCoordinator {
+                    CalendarSettingsView(coordinator: settingsCoordinator, showsDoneButton: false)
+                } else {
+                    ContentUnavailableView {
+                        Label("无法打开设置", systemSymbol: .gearshape)
+                    } description: {
+                        Text("当前日历数据尚未准备完成。")
+                    }
+                }
             }
+            .tabItem {
+                Label(CalendarTab.settings.title, systemSymbol: CalendarTab.settings.systemSymbol)
+            }
+            .tag(CalendarTab.settings)
         }
     }
 
@@ -50,6 +55,7 @@ struct CalendarHomeTabView: View {
             canSelectNextYear: router.canSelectNextYear(availableYearNumbers: yearNumbers),
             selectPreviousYear: { router.selectPreviousYear(availableYearNumbers: yearNumbers) },
             selectNextYear: { router.selectNextYear(availableYearNumbers: yearNumbers) },
+            showYearList: { router.setPath([], for: .years) },
             emptyStateDescription: emptyStateDescription
         )
     }

--- a/Sources/ChineseCalendarUI/CalendarHomeView.swift
+++ b/Sources/ChineseCalendarUI/CalendarHomeView.swift
@@ -5,19 +5,19 @@ import Foundation
 import SwiftData
 import SwiftUI
 
-public struct CalendarHomeView: View {
+public struct CalendarHomeView<BottomStatusBar: View>: View {
     @Query(sort: \ChineseLunarYear.lunarYearNumber) private var years: [ChineseLunarYear]
     @State private var router = CalendarRouter()
     @State private var didOpenColdLaunchDeepLink = false
     private let settingsCoordinator: ChineseCalendarStoreCoordinator?
+    private let bottomStatusBar: () -> BottomStatusBar
 
-    public init(settingsCoordinator: ChineseCalendarStoreCoordinator? = nil) {
+    public init(
+        settingsCoordinator: ChineseCalendarStoreCoordinator? = nil,
+        @ViewBuilder bottomStatusBar: @escaping () -> BottomStatusBar
+    ) {
         self.settingsCoordinator = settingsCoordinator
-    }
-
-    @available(*, deprecated, message: "CalendarHomeView now selects the current lunar year automatically.")
-    public init(selectedDate _: ChineseCalendarDate?) {
-        self.init()
+        self.bottomStatusBar = bottomStatusBar
     }
 
     public var body: some View {
@@ -29,7 +29,8 @@ public struct CalendarHomeView: View {
                     router: router,
                     years: years,
                     emptyStateDescription: emptyStateDescription,
-                    settingsCoordinator: settingsCoordinator
+                    settingsCoordinator: settingsCoordinator,
+                    bottomStatusBar: bottomStatusBar
                 )
             #else
                 CalendarHomeSplitView(
@@ -104,4 +105,16 @@ public struct CalendarHomeView: View {
 
 #Preview {
     CalendarHomeView()
+}
+
+public extension CalendarHomeView where BottomStatusBar == EmptyView {
+    init(settingsCoordinator: ChineseCalendarStoreCoordinator? = nil) {
+        self.settingsCoordinator = settingsCoordinator
+        bottomStatusBar = { EmptyView() }
+    }
+
+    @available(*, deprecated, message: "CalendarHomeView now selects the current lunar year automatically.")
+    init(selectedDate _: ChineseCalendarDate?) {
+        self.init()
+    }
 }

--- a/Sources/ChineseCalendarUI/CalendarHomeView.swift
+++ b/Sources/ChineseCalendarUI/CalendarHomeView.swift
@@ -9,10 +9,10 @@ public struct CalendarHomeView: View {
     @Query(sort: \ChineseLunarYear.lunarYearNumber) private var years: [ChineseLunarYear]
     @State private var router = CalendarRouter()
     @State private var didOpenColdLaunchDeepLink = false
-    private let openSettings: (() -> Void)?
+    private let settingsCoordinator: ChineseCalendarStoreCoordinator?
 
-    public init(openSettings: (() -> Void)? = nil) {
-        self.openSettings = openSettings
+    public init(settingsCoordinator: ChineseCalendarStoreCoordinator? = nil) {
+        self.settingsCoordinator = settingsCoordinator
     }
 
     @available(*, deprecated, message: "CalendarHomeView now selects the current lunar year automatically.")
@@ -29,7 +29,7 @@ public struct CalendarHomeView: View {
                     router: router,
                     years: years,
                     emptyStateDescription: emptyStateDescription,
-                    openSettings: openSettings
+                    settingsCoordinator: settingsCoordinator
                 )
             #else
                 CalendarHomeSplitView(

--- a/Sources/ChineseCalendarUI/CalendarRouteDestinationView.swift
+++ b/Sources/ChineseCalendarUI/CalendarRouteDestinationView.swift
@@ -10,6 +10,7 @@ struct CalendarRouteDestinationView: View {
     let canSelectNextYear: Bool
     let selectPreviousYear: () -> Void
     let selectNextYear: () -> Void
+    let showYearList: (() -> Void)?
     let emptyStateDescription: String
 
     init(
@@ -20,6 +21,7 @@ struct CalendarRouteDestinationView: View {
         canSelectNextYear: Bool,
         selectPreviousYear: @escaping () -> Void,
         selectNextYear: @escaping () -> Void,
+        showYearList: (() -> Void)? = nil,
         emptyStateDescription: String
     ) {
         self.route = route
@@ -29,6 +31,7 @@ struct CalendarRouteDestinationView: View {
         self.canSelectNextYear = canSelectNextYear
         self.selectPreviousYear = selectPreviousYear
         self.selectNextYear = selectNextYear
+        self.showYearList = showYearList
         self.emptyStateDescription = emptyStateDescription
     }
 
@@ -43,7 +46,8 @@ struct CalendarRouteDestinationView: View {
                         canSelectPreviousYear: canSelectPreviousYear,
                         canSelectNextYear: canSelectNextYear,
                         selectPreviousYear: selectPreviousYear,
-                        selectNextYear: selectNextYear
+                        selectNextYear: selectNextYear,
+                        showYearList: showYearList
                     )
                 } else {
                     ContentUnavailableView {

--- a/Sources/ChineseCalendarUI/CalendarRouter.swift
+++ b/Sources/ChineseCalendarUI/CalendarRouter.swift
@@ -55,6 +55,8 @@ final class CalendarRouter {
             yearsPath
         case .history:
             historyPath
+        case .settings:
+            []
         }
     }
 
@@ -64,6 +66,8 @@ final class CalendarRouter {
             yearsPath = path
         case .history:
             historyPath = path
+        case .settings:
+            break
         }
     }
 

--- a/Sources/ChineseCalendarUI/CalendarSettingsView.swift
+++ b/Sources/ChineseCalendarUI/CalendarSettingsView.swift
@@ -4,13 +4,15 @@ import SwiftUI
 
 public struct CalendarSettingsView: View {
     private let coordinator: ChineseCalendarStoreCoordinator
+    private let showsDoneButton: Bool
 
     @Environment(\.dismiss) private var dismiss
     @State private var isConfirmingClear = false
     @State private var resultMessage: SettingsResultMessage?
 
-    public init(coordinator: ChineseCalendarStoreCoordinator) {
+    public init(coordinator: ChineseCalendarStoreCoordinator, showsDoneButton: Bool = true) {
         self.coordinator = coordinator
+        self.showsDoneButton = showsDoneButton
     }
 
     public var body: some View {
@@ -44,9 +46,11 @@ public struct CalendarSettingsView: View {
         #if os(iOS)
         .navigationTitle("设置")
         .toolbar {
-            ToolbarItem(placement: .confirmationAction) {
-                Button("完成") {
-                    dismiss()
+            if showsDoneButton {
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("完成") {
+                        dismiss()
+                    }
                 }
             }
         }

--- a/Sources/ChineseCalendarUI/CalendarTab.swift
+++ b/Sources/ChineseCalendarUI/CalendarTab.swift
@@ -4,6 +4,7 @@ import SFSafeSymbols
 enum CalendarTab: Hashable, CaseIterable, Identifiable {
     case years
     case history
+    case settings
 
     var id: Self {
         self
@@ -12,9 +13,11 @@ enum CalendarTab: Hashable, CaseIterable, Identifiable {
     var title: String {
         switch self {
         case .years:
-            "年份"
+            "日历"
         case .history:
             "历史"
+        case .settings:
+            "设置"
         }
     }
 
@@ -24,6 +27,8 @@ enum CalendarTab: Hashable, CaseIterable, Identifiable {
             .calendar
         case .history:
             .timelineSelection
+        case .settings:
+            .gearshape
         }
     }
 }

--- a/Sources/ChineseCalendarUI/ChineseCalendarRootView.swift
+++ b/Sources/ChineseCalendarUI/ChineseCalendarRootView.swift
@@ -7,7 +7,6 @@ import SwiftUI
 public struct ChineseCalendarRootView: View {
     @Environment(\.openWindow) private var openWindow
     @State private var coordinator: ChineseCalendarStoreCoordinator
-    @State private var isSettingsPresented = false
 
     public init(coordinator: ChineseCalendarStoreCoordinator) {
         _coordinator = State(initialValue: coordinator)
@@ -27,7 +26,7 @@ public struct ChineseCalendarRootView: View {
             case .starting:
                 CalendarStoreProgressView(title: "正在准备日历数据", progress: nil)
             case let .ready(container, contentLevel, identityToken):
-                CalendarHomeView(openSettings: showSettings)
+                CalendarHomeView(settingsCoordinator: coordinator)
                     .environment(\.calendarStoreContentLevel, contentLevel)
                     .modelContainer(container)
                     .id(coordinator.storeIdentity(contentLevel: contentLevel, identityToken: identityToken))
@@ -36,11 +35,6 @@ public struct ChineseCalendarRootView: View {
                     }
             case let .failed(message):
                 CalendarStoreFailureView(message: message, retry: coordinator.prepareStore)
-            }
-        }
-        .sheet(isPresented: $isSettingsPresented) {
-            NavigationStack {
-                CalendarSettingsView(coordinator: coordinator)
             }
         }
         .task {
@@ -62,10 +56,6 @@ public struct ChineseCalendarRootView: View {
                 }
             }
         )
-    }
-
-    private func showSettings() {
-        isSettingsPresented = true
     }
 
     @ViewBuilder

--- a/Sources/ChineseCalendarUI/ChineseCalendarRootView.swift
+++ b/Sources/ChineseCalendarUI/ChineseCalendarRootView.swift
@@ -26,13 +26,11 @@ public struct ChineseCalendarRootView: View {
             case .starting:
                 CalendarStoreProgressView(title: "正在准备日历数据", progress: nil)
             case let .ready(container, contentLevel, identityToken):
-                CalendarHomeView(settingsCoordinator: coordinator)
-                    .environment(\.calendarStoreContentLevel, contentLevel)
-                    .modelContainer(container)
-                    .id(coordinator.storeIdentity(contentLevel: contentLevel, identityToken: identityToken))
-                    .safeAreaInset(edge: .bottom) {
-                        bottomStatusBar(contentLevel: contentLevel)
-                    }
+                readyCalendarHome(
+                    container: container,
+                    contentLevel: contentLevel,
+                    identityToken: identityToken
+                )
             case let .failed(message):
                 CalendarStoreFailureView(message: message, retry: coordinator.prepareStore)
             }
@@ -45,6 +43,30 @@ public struct ChineseCalendarRootView: View {
         } message: {
             Text(coordinator.downloadErrorMessage ?? "请稍后再试。")
         }
+    }
+
+    @ViewBuilder
+    private func readyCalendarHome(
+        container: ModelContainer,
+        contentLevel: ChineseCalendarSeedStoreContentLevel,
+        identityToken: String?
+    ) -> some View {
+        #if os(iOS)
+            CalendarHomeView(settingsCoordinator: coordinator) {
+                bottomStatusBar(contentLevel: contentLevel)
+            }
+            .environment(\.calendarStoreContentLevel, contentLevel)
+            .modelContainer(container)
+            .id(coordinator.storeIdentity(contentLevel: contentLevel, identityToken: identityToken))
+        #else
+            CalendarHomeView(settingsCoordinator: coordinator)
+                .environment(\.calendarStoreContentLevel, contentLevel)
+                .modelContainer(container)
+                .id(coordinator.storeIdentity(contentLevel: contentLevel, identityToken: identityToken))
+                .safeAreaInset(edge: .bottom) {
+                    bottomStatusBar(contentLevel: contentLevel)
+                }
+        #endif
     }
 
     private var downloadErrorIsPresented: Binding<Bool> {

--- a/Sources/ChineseCalendarUI/DynastySummaryChip.swift
+++ b/Sources/ChineseCalendarUI/DynastySummaryChip.swift
@@ -1,0 +1,15 @@
+import SwiftUI
+
+struct DynastySummaryChip: View {
+    let title: String
+
+    var body: some View {
+        Text(title)
+            .font(.caption)
+            .bold()
+            .foregroundStyle(.secondary)
+            .padding(.horizontal, 8)
+            .padding(.vertical, 5)
+            .background(.background, in: Capsule())
+    }
+}

--- a/Sources/ChineseCalendarUI/LunarDayGridCell.swift
+++ b/Sources/ChineseCalendarUI/LunarDayGridCell.swift
@@ -1,0 +1,74 @@
+import ChineseCalendarCore
+import ChineseCalendarPersistence
+import SwiftUI
+
+struct LunarDayGridCell: View {
+    let day: ChineseLunarDay
+    let isSelected: Bool
+    let isToday: Bool
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack(alignment: .firstTextBaseline) {
+                Text(dayTitle)
+                    .font(.headline)
+
+                Spacer(minLength: 4)
+
+                if isToday {
+                    Text("今日")
+                        .font(.caption)
+                        .bold()
+                        .padding(.horizontal, 6)
+                        .padding(.vertical, 2)
+                        .foregroundStyle(isSelected ? Color.accentColor : Color.white)
+                        .background(isSelected ? Color.white.opacity(0.86) : Color.accentColor, in: Capsule())
+                }
+            }
+
+            Text(daySubtitle)
+                .font(.subheadline)
+                .foregroundStyle(isSelected ? Color.white.opacity(0.82) : Color.secondary)
+
+            Text(civilDateTitle)
+                .font(.subheadline)
+                .foregroundStyle(isSelected ? Color.white.opacity(0.66) : Color.secondary)
+        }
+        .foregroundStyle(isSelected ? Color.white : Color.primary)
+        .padding(10)
+        .frame(maxWidth: .infinity, minHeight: 72, alignment: .topLeading)
+        .background(.background, in: RoundedRectangle(cornerRadius: 18))
+        .background {
+            if isSelected {
+                RoundedRectangle(cornerRadius: 18)
+                    .fill(Color.accentColor)
+            }
+        }
+        .overlay {
+            RoundedRectangle(cornerRadius: 18)
+                .stroke(isToday && !isSelected ? Color.accentColor : Color.primary.opacity(0.08))
+        }
+        .accessibilityElement(children: .combine)
+    }
+
+    private var dayTitle: String {
+        LunarCalendarFormatting.dayTitle(dayNumberInMonth: day.dayNumberInMonth)
+    }
+
+    private var daySubtitle: String {
+        "\(LunarCalendarFormatting.daySubtitle(stemIndex: day.dayStemIndex, branchIndex: day.dayBranchIndex))日"
+    }
+
+    private var civilDateTitle: String {
+        guard let civilDate = day.calendarDay?.civilDate else {
+            return "-"
+        }
+
+        return LunarCalendarFormatting.civilDateTitle(
+            year: civilDate.year,
+            month: civilDate.month,
+            dayOfMonth: civilDate.dayOfMonth,
+            isJulianCalendar: civilDate.calendarStyle == .julian
+        )
+    }
+}

--- a/Sources/ChineseCalendarUI/LunarMonthDisplay.swift
+++ b/Sources/ChineseCalendarUI/LunarMonthDisplay.swift
@@ -1,0 +1,13 @@
+import ChineseCalendarCore
+import ChineseCalendarPersistence
+
+enum LunarMonthDisplay {
+    static func title(for month: ChineseLunarMonth) -> String {
+        LunarCalendarFormatting.monthTitle(
+            monthNumberInYear: month.monthNumberInYear,
+            isLeapMonth: month.isLeapMonth,
+            intercalaryMonthNameStyle: month.intercalaryMonthNameStyle,
+            dayCount: month.dayCount
+        )
+    }
+}

--- a/Sources/ChineseCalendarUI/LunarMonthGrid.swift
+++ b/Sources/ChineseCalendarUI/LunarMonthGrid.swift
@@ -118,9 +118,8 @@ struct LunarMonthGrid: View {
     }
 
     private var selectedDay: ChineseLunarDay? {
-        if let selectedDayIndex,
-           let selectedDay = days.first(where: { $0.dayIndex == selectedDayIndex }) {
-            return selectedDay
+        if let selectedDayIndex {
+            return days.first { $0.dayIndex == selectedDayIndex } ?? defaultSelectedDay
         }
 
         return defaultSelectedDay
@@ -194,9 +193,10 @@ struct LunarMonthGrid: View {
             return
         }
 
-        if let selectedDayIndex,
-           days.contains(where: { $0.dayIndex == selectedDayIndex }) {
-            return
+        if let selectedDayIndex {
+            guard !days.contains(where: { $0.dayIndex == selectedDayIndex }) else {
+                return
+            }
         }
 
         selectedDayIndex = defaultSelectedDay?.dayIndex

--- a/Sources/ChineseCalendarUI/LunarMonthGrid.swift
+++ b/Sources/ChineseCalendarUI/LunarMonthGrid.swift
@@ -1,16 +1,36 @@
 import ChineseCalendarCore
 import ChineseCalendarPersistence
+import Foundation
 import SFSafeSymbols
 import SwiftData
 import SwiftUI
 
 struct LunarMonthGrid: View {
+    let year: ChineseLunarYear
+    let months: [ChineseLunarMonth]
     let month: ChineseLunarMonth
-    @Environment(\.calendarStoreContentLevel) private var storeContentLevel
-    @Query private var days: [ChineseLunarDay]
+    @Binding var selectedMonthIndex: Int?
+    let showYearList: (() -> Void)?
 
-    init(month: ChineseLunarMonth) {
+    @Environment(\.calendarStoreContentLevel) private var storeContentLevel
+    @State private var selectedDayIndex: Int?
+    @Query private var days: [ChineseLunarDay]
+    private let todayComponents: DateComponents
+
+    init(
+        year: ChineseLunarYear,
+        months: [ChineseLunarMonth],
+        month: ChineseLunarMonth,
+        selectedMonthIndex: Binding<Int?>,
+        showYearList: (() -> Void)? = nil,
+        today: Date = .now
+    ) {
+        self.year = year
+        self.months = months
         self.month = month
+        _selectedMonthIndex = selectedMonthIndex
+        self.showYearList = showYearList
+        todayComponents = Self.gregorianDateComponents(for: today)
 
         let lunarMonthIndex = month.lunarMonthIndex
         _days = Query(
@@ -21,17 +41,20 @@ struct LunarMonthGrid: View {
         )
     }
 
-    private var periods: [LunarTenDayPeriod] {
-        LunarTenDayPeriod.makePeriods(from: days)
-    }
-
     var body: some View {
-        VStack(alignment: .leading, spacing: 12) {
-            Text("本月日期")
-                .font(.title2)
-                .bold()
+        VStack(alignment: .leading, spacing: 16) {
+            MonthSwitcher(
+                title: monthNavigationTitle,
+                subtitle: monthNavigationSubtitle,
+                months: months,
+                selectedMonth: month,
+                selectedMonthIndex: $selectedMonthIndex,
+                showYearList: showYearList
+            )
+            .padding()
+            .background(.background.secondary, in: RoundedRectangle(cornerRadius: 28))
 
-            if periods.isEmpty {
+            if days.isEmpty {
                 ContentUnavailableView(
                     label: {
                         Label(emptyStateTitle, systemSymbol: emptyStateSystemSymbol)
@@ -40,18 +63,102 @@ struct LunarMonthGrid: View {
                         Text(emptyStateDescription)
                     }
                 )
+                .padding()
                 .frame(maxWidth: .infinity, alignment: .leading)
+                .background(.background.secondary, in: RoundedRectangle(cornerRadius: 28))
             } else {
-                ScrollView(.horizontal) {
-                    VStack(alignment: .leading, spacing: 10) {
-                        ForEach(periods) { period in
-                            LunarTenDayPeriodRow(period: period)
+                VStack(alignment: .leading, spacing: 12) {
+                    HStack(alignment: .firstTextBaseline) {
+                        Text("农历月格")
+                            .font(.title2)
+                            .bold()
+
+                        Spacer()
+
+                        Text("连续日序")
+                            .font(.subheadline)
+                            .foregroundStyle(.secondary)
+                    }
+
+                    LazyVGrid(columns: gridColumns, alignment: .leading, spacing: 8) {
+                        ForEach(days, id: \.dayIndex) { day in
+                            Button {
+                                selectedDayIndex = day.dayIndex
+                            } label: {
+                                LunarDayGridCell(
+                                    day: day,
+                                    isSelected: day.dayIndex == selectedDay?.dayIndex,
+                                    isToday: isToday(day)
+                                )
+                            }
+                            .buttonStyle(.plain)
                         }
                     }
                 }
-                .scrollIndicators(.hidden)
+                .padding()
+                .background(.background.secondary, in: RoundedRectangle(cornerRadius: 28))
+
+                if let selectedDay {
+                    SelectedLunarDayDetailCard(
+                        day: selectedDay,
+                        month: month,
+                        contentLevel: storeContentLevel
+                    )
+                }
             }
         }
+        .onAppear(perform: selectDefaultDayIfNeeded)
+        .onChange(of: days.map(\.dayIndex)) {
+            selectDefaultDayIfNeeded()
+        }
+    }
+
+    private var gridColumns: [GridItem] {
+        [GridItem(.adaptive(minimum: 58), spacing: 8)]
+    }
+
+    private var selectedDay: ChineseLunarDay? {
+        if let selectedDayIndex,
+           let selectedDay = days.first(where: { $0.dayIndex == selectedDayIndex }) {
+            return selectedDay
+        }
+
+        return defaultSelectedDay
+    }
+
+    private var defaultSelectedDay: ChineseLunarDay? {
+        days.first(where: isToday) ?? days.first
+    }
+
+    private var monthNavigationTitle: String {
+        let yearTitle = LunarCalendarFormatting.yearSubtitle(
+            stemIndex: year.yearStemIndex,
+            branchIndex: year.yearBranchIndex
+        )
+        return "\(yearTitle) \(LunarMonthDisplay.title(for: month))"
+    }
+
+    private var monthNavigationSubtitle: String {
+        if let civilDateRangeTitle {
+            let selectionText = defaultSelectedDay.map(isToday) == true ? "今天优先选中" : "默认选中初一"
+            return "\(civilDateRangeTitle) · \(selectionText)"
+        }
+
+        return LunarCalendarFormatting.monthSubtitle(
+            dayCount: month.dayCount,
+            stemIndex: month.monthStemIndex,
+            branchIndex: month.monthBranchIndex
+        )
+    }
+
+    private var civilDateRangeTitle: String? {
+        guard let firstCivilDate = days.first?.calendarDay?.civilDate,
+              let lastCivilDate = days.last?.calendarDay?.civilDate
+        else {
+            return nil
+        }
+
+        return "\(fullCivilDateTitle(for: firstCivilDate)) - \(fullCivilDateTitle(for: lastCivilDate))"
     }
 
     private var emptyStateTitle: String {
@@ -80,76 +187,41 @@ struct LunarMonthGrid: View {
             "这个月份暂时没有可显示的日级记录。"
         }
     }
-}
 
-private struct LunarTenDayPeriod: Identifiable {
-    let id: Int
-    let title: String
-    let days: [ChineseLunarDay]
-
-    static func makePeriods(from days: [ChineseLunarDay]) -> [Self] {
-        [
-            Self(id: 0, title: "上旬", days: days.filter { (1 ... 10).contains($0.dayNumberInMonth) }),
-            Self(id: 1, title: "中旬", days: days.filter { (11 ... 20).contains($0.dayNumberInMonth) }),
-            Self(id: 2, title: "下旬", days: days.filter { (21 ... 30).contains($0.dayNumberInMonth) })
-        ]
-        .filter { !$0.days.isEmpty }
-    }
-}
-
-private struct LunarTenDayPeriodRow: View {
-    let period: LunarTenDayPeriod
-
-    var body: some View {
-        HStack(alignment: .top, spacing: 8) {
-            Text(period.title)
-                .font(.headline)
-                .foregroundStyle(.secondary)
-                .frame(width: 48, alignment: .topLeading)
-                .frame(minHeight: 88, alignment: .topLeading)
-
-            ForEach(period.days, id: \.dayIndex) { day in
-                LunarDayCell(day: day)
-            }
-        }
-        .accessibilityElement(children: .contain)
-    }
-}
-
-private struct LunarDayCell: View {
-    let day: ChineseLunarDay
-
-    var body: some View {
-        VStack(alignment: .leading, spacing: 6) {
-            Text(LunarCalendarFormatting.dayTitle(dayNumberInMonth: day.dayNumberInMonth))
-                .font(.headline)
-            Text(LunarCalendarFormatting.daySubtitle(
-                stemIndex: day.dayStemIndex,
-                branchIndex: day.dayBranchIndex
-            ))
-            .font(.subheadline)
-            .foregroundStyle(.secondary)
-            Text(civilDateTitle)
-                .font(.subheadline)
-                .foregroundStyle(.tertiary)
-        }
-        .padding(10)
-        .frame(width: 96, alignment: .topLeading)
-        .frame(minHeight: 88, alignment: .topLeading)
-        .background(.background.secondary, in: RoundedRectangle(cornerRadius: 8))
-        .accessibilityElement(children: .combine)
-    }
-
-    private var civilDateTitle: String {
-        guard let civilDate = day.calendarDay?.civilDate else {
-            return "-"
+    private func selectDefaultDayIfNeeded() {
+        guard !days.isEmpty else {
+            selectedDayIndex = nil
+            return
         }
 
-        return LunarCalendarFormatting.civilDateTitle(
-            year: civilDate.year,
-            month: civilDate.month,
-            dayOfMonth: civilDate.dayOfMonth,
-            isJulianCalendar: civilDate.calendarStyle == .julian
-        )
+        if let selectedDayIndex,
+           days.contains(where: { $0.dayIndex == selectedDayIndex }) {
+            return
+        }
+
+        selectedDayIndex = defaultSelectedDay?.dayIndex
+    }
+
+    private func isToday(_ day: ChineseLunarDay) -> Bool {
+        guard let civilDate = day.calendarDay?.civilDate,
+              civilDate.calendarStyle == .gregorian
+        else {
+            return false
+        }
+
+        return civilDate.year == todayComponents.year
+            && civilDate.month == todayComponents.month
+            && civilDate.dayOfMonth == todayComponents.day
+    }
+
+    private func fullCivilDateTitle(for civilDate: CivilDate) -> String {
+        let prefix = civilDate.calendarStyle == .julian ? "儒略" : "公历"
+        return "\(prefix) \(civilDate.year)年\(civilDate.month)月\(civilDate.dayOfMonth)日"
+    }
+
+    private static func gregorianDateComponents(for date: Date) -> DateComponents {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = .autoupdatingCurrent
+        return calendar.dateComponents([.year, .month, .day], from: date)
     }
 }

--- a/Sources/ChineseCalendarUI/LunarYearDetailView.swift
+++ b/Sources/ChineseCalendarUI/LunarYearDetailView.swift
@@ -11,8 +11,10 @@ struct LunarYearDetailView: View {
     let canSelectNextYear: Bool
     let selectPreviousYear: () -> Void
     let selectNextYear: () -> Void
+    let showYearList: (() -> Void)?
 
     @Query private var months: [ChineseLunarMonth]
+    @Query private var todayCivilDates: [CivilDate]
 
     init(
         year: ChineseLunarYear,
@@ -20,7 +22,9 @@ struct LunarYearDetailView: View {
         canSelectPreviousYear: Bool,
         canSelectNextYear: Bool,
         selectPreviousYear: @escaping () -> Void,
-        selectNextYear: @escaping () -> Void
+        selectNextYear: @escaping () -> Void,
+        showYearList: (() -> Void)? = nil,
+        today: Date = .now
     ) {
         self.year = year
         _selectedMonthIndex = selectedMonthIndex
@@ -28,6 +32,7 @@ struct LunarYearDetailView: View {
         self.canSelectNextYear = canSelectNextYear
         self.selectPreviousYear = selectPreviousYear
         self.selectNextYear = selectNextYear
+        self.showYearList = showYearList
 
         let lunarYearNumber = year.lunarYearNumber
         _months = Query(
@@ -35,6 +40,21 @@ struct LunarYearDetailView: View {
                 month.lunarYearNumber == lunarYearNumber
             },
             sort: \ChineseLunarMonth.lunarMonthIndex
+        )
+
+        let todayComponents = Self.gregorianDateComponents(for: today)
+        let todayYear = todayComponents.year ?? 0
+        let todayMonth = todayComponents.month ?? 0
+        let todayDay = todayComponents.day ?? 0
+        let gregorianCalendarStyle = CivilCalendarStyle.gregorian.rawValue
+        _todayCivilDates = Query(
+            filter: #Predicate<CivilDate> { civilDate in
+                civilDate.year == todayYear
+                    && civilDate.month == todayMonth
+                    && civilDate.dayOfMonth == todayDay
+                    && civilDate.calendarStyleRawValue == gregorianCalendarStyle
+            },
+            sort: \CivilDate.dayIndex
         )
     }
 
@@ -54,22 +74,19 @@ struct LunarYearDetailView: View {
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 24) {
-                Text(yearSubtitle)
-                    .font(.subheadline)
-                    .foregroundStyle(.secondary)
-
                 if monthsInYearStartOrder.isEmpty {
                     ContentUnavailableView {
                         Label("没有月份数据", systemSymbol: .calendarBadgeExclamationmark)
                     }
                 } else if let selectedMonth {
-                    MonthSwitcher(
+                    LunarMonthGrid(
+                        year: year,
                         months: monthsInYearStartOrder,
-                        selectedMonth: selectedMonth,
-                        selectedMonthIndex: $selectedMonthIndex
+                        month: selectedMonth,
+                        selectedMonthIndex: $selectedMonthIndex,
+                        showYearList: showYearList
                     )
-
-                    LunarMonthGrid(month: selectedMonth)
+                    .id(selectedMonth.lunarMonthIndex)
                 }
             }
             .padding()
@@ -79,7 +96,7 @@ struct LunarYearDetailView: View {
         .onChange(of: year.lunarYearNumber) {
             selectDefaultMonthIfNeeded()
         }
-        .navigationTitle(LunarCalendarFormatting.yearTitle(lunarYearNumber: year.lunarYearNumber))
+        .navigationTitle("日历")
         .toolbar {
             ToolbarItemGroup(placement: .primaryAction) {
                 Button("上一年", systemSymbol: .chevronLeft, action: selectPreviousYear)
@@ -93,12 +110,12 @@ struct LunarYearDetailView: View {
         }
     }
 
-    private var yearSubtitle: String {
-        let sexagenaryYear = LunarCalendarFormatting.yearSubtitle(
-            stemIndex: year.yearStemIndex,
-            branchIndex: year.yearBranchIndex
-        )
-        return "\(sexagenaryYear) · \(monthsInYearStartOrder.count)个月"
+    private var todayMonthIndex: Int? {
+        let monthIndexes = Set(monthsInYearStartOrder.map(\.lunarMonthIndex))
+        return todayCivilDates
+            .lazy
+            .compactMap { $0.calendarDay?.chineseLunarDay?.lunarMonthIndex }
+            .first { monthIndexes.contains($0) }
     }
 
     private func selectDefaultMonthIfNeeded() {
@@ -106,6 +123,12 @@ struct LunarYearDetailView: View {
             return
         }
 
-        selectedMonthIndex = monthsInYearStartOrder.first?.lunarMonthIndex
+        selectedMonthIndex = todayMonthIndex ?? monthsInYearStartOrder.first?.lunarMonthIndex
+    }
+
+    private static func gregorianDateComponents(for date: Date) -> DateComponents {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = .autoupdatingCurrent
+        return calendar.dateComponents([.year, .month, .day], from: date)
     }
 }

--- a/Sources/ChineseCalendarUI/MonthSwitcher.swift
+++ b/Sources/ChineseCalendarUI/MonthSwitcher.swift
@@ -4,9 +4,12 @@ import SFSafeSymbols
 import SwiftUI
 
 struct MonthSwitcher: View {
+    let title: String
+    let subtitle: String
     let months: [ChineseLunarMonth]
     let selectedMonth: ChineseLunarMonth
     @Binding var selectedMonthIndex: Int?
+    let showYearList: (() -> Void)?
 
     private var selectedIndex: Int? {
         months.firstIndex { $0.lunarMonthIndex == selectedMonth.lunarMonthIndex }
@@ -30,28 +33,23 @@ struct MonthSwitcher: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {
-            HStack(spacing: 12) {
+            HStack(alignment: .center, spacing: 10) {
                 Button("上个月", systemSymbol: .chevronLeft, action: selectPreviousMonth)
                     .labelStyle(.iconOnly)
+                    .frame(width: 44, height: 44)
+                    .buttonStyle(.bordered)
+                    .controlSize(.large)
                     .disabled(!canSelectPreviousMonth)
                     .help("切换到上个月")
 
-                VStack(alignment: .leading) {
-                    Text(monthTitle(selectedMonth))
-                        .font(.headline)
-                    Text(LunarCalendarFormatting.monthSubtitle(
-                        dayCount: selectedMonth.dayCount,
-                        stemIndex: selectedMonth.monthStemIndex,
-                        branchIndex: selectedMonth.monthBranchIndex
-                    ))
-                    .font(.subheadline)
-                    .foregroundStyle(.secondary)
-                }
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .accessibilityElement(children: .combine)
+                titleContent
+                    .frame(maxWidth: .infinity, alignment: .leading)
 
                 Button("下个月", systemSymbol: .chevronRight, action: selectNextMonth)
                     .labelStyle(.iconOnly)
+                    .frame(width: 44, height: 44)
+                    .buttonStyle(.bordered)
+                    .controlSize(.large)
                     .disabled(!canSelectNextMonth)
                     .help("切换到下个月")
             }
@@ -63,7 +61,7 @@ struct MonthSwitcher: View {
                             selectedMonthIndex = month.lunarMonthIndex
                         } label: {
                             VStack(spacing: 4) {
-                                Text(monthTitle(month))
+                                Text(LunarMonthDisplay.title(for: month))
                                 Text("\(month.dayCount)天")
                                     .font(.caption)
                                     .foregroundStyle(.secondary)
@@ -82,6 +80,32 @@ struct MonthSwitcher: View {
         }
     }
 
+    @ViewBuilder
+    private var titleContent: some View {
+        if let showYearList {
+            Button(action: showYearList) {
+                monthTitleContent
+            }
+            .buttonStyle(.plain)
+            .contentShape(Rectangle())
+            .accessibilityHint("打开农历年列表")
+        } else {
+            monthTitleContent
+        }
+    }
+
+    private var monthTitleContent: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(title)
+                .font(.title2)
+                .bold()
+            Text(subtitle)
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+        }
+        .accessibilityElement(children: .combine)
+    }
+
     private func selectPreviousMonth() {
         guard let selectedIndex, selectedIndex > months.startIndex else {
             return
@@ -96,14 +120,5 @@ struct MonthSwitcher: View {
         }
 
         selectedMonthIndex = months[months.index(after: selectedIndex)].lunarMonthIndex
-    }
-
-    private func monthTitle(_ month: ChineseLunarMonth) -> String {
-        LunarCalendarFormatting.monthTitle(
-            monthNumberInYear: month.monthNumberInYear,
-            isLeapMonth: month.isLeapMonth,
-            intercalaryMonthNameStyle: month.intercalaryMonthNameStyle,
-            dayCount: month.dayCount
-        )
     }
 }

--- a/Sources/ChineseCalendarUI/OrthodoxPeriodRow.swift
+++ b/Sources/ChineseCalendarUI/OrthodoxPeriodRow.swift
@@ -5,15 +5,37 @@ struct OrthodoxPeriodRow: View {
     let period: OrthodoxPeriod
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 4) {
-            Text(period.dynasty?.name ?? period.segmentName)
+        HStack(alignment: .top, spacing: 12) {
+            Text(sequenceText)
                 .font(.headline)
+                .bold()
+                .foregroundStyle(.tint)
+                .frame(width: 44, height: 44)
+                .background(.tint.opacity(0.14), in: RoundedRectangle(cornerRadius: 16))
 
-            Text(subtitle)
-                .font(.subheadline)
-                .foregroundStyle(.secondary)
+            VStack(alignment: .leading, spacing: 8) {
+                Text(period.dynasty?.name ?? period.segmentName)
+                    .font(.headline)
+
+                Text(subtitle)
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+
+                HStack(spacing: 6) {
+                    DynastySummaryChip(title: "\(emperorCount) 位皇帝")
+                    DynastySummaryChip(title: "\(reignEraCount) 个年号")
+                }
+            }
         }
+        .padding()
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(.background.secondary, in: RoundedRectangle(cornerRadius: 24))
         .accessibilityElement(children: .combine)
+    }
+
+    private var sequenceText: String {
+        let sequenceNumber = period.sequenceIndex + 1
+        return sequenceNumber < 10 ? "0\(sequenceNumber)" : "\(sequenceNumber)"
     }
 
     private var subtitle: String {
@@ -21,5 +43,15 @@ struct OrthodoxPeriodRow: View {
         let startText = period.startBoundary?.date.sourceText ?? "起点不详"
         let endText = period.endBoundary?.date.sourceText ?? "终点不详"
         return "\(segmentText) · \(startText) - \(endText)"
+    }
+
+    private var emperorCount: Int {
+        period.dynasty?.emperors.count ?? 0
+    }
+
+    private var reignEraCount: Int {
+        period.dynasty?.emperors.reduce(0) { count, emperor in
+            count + emperor.reignEras.count
+        } ?? 0
     }
 }

--- a/Sources/ChineseCalendarUI/SelectedLunarDayDetailCard.swift
+++ b/Sources/ChineseCalendarUI/SelectedLunarDayDetailCard.swift
@@ -1,0 +1,102 @@
+import ChineseCalendarCore
+import ChineseCalendarPersistence
+import SwiftUI
+
+struct SelectedLunarDayDetailCard: View {
+    let day: ChineseLunarDay
+    let month: ChineseLunarMonth
+    let contentLevel: ChineseCalendarSeedStoreContentLevel
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            HStack(alignment: .top, spacing: 16) {
+                VStack(alignment: .leading, spacing: 6) {
+                    Text("选中日")
+                        .font(.caption)
+                        .bold()
+                        .foregroundStyle(.tint)
+                    Text(dayTitle)
+                        .font(.largeTitle)
+                        .bold()
+                    Text(daySubtitle)
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                }
+
+                Spacer()
+
+                Text(sealText)
+                    .font(.title2)
+                    .bold()
+                    .foregroundStyle(.white)
+                    .frame(width: 54, height: 54)
+                    .background(Color.accentColor, in: RoundedRectangle(cornerRadius: 18))
+                    .accessibilityHidden(true)
+            }
+
+            LazyVGrid(columns: columns, alignment: .leading, spacing: 10) {
+                CalendarFactTile(title: "农历表达", value: lunarExpression)
+                CalendarFactTile(title: "日干支", value: dayStemBranch)
+                CalendarFactTile(title: civilDateFactTitle, value: civilDateValue)
+                CalendarFactTile(title: "数据层级", value: contentLevelTitle)
+            }
+        }
+        .padding()
+        .background(.background.secondary, in: RoundedRectangle(cornerRadius: 28))
+        .accessibilityElement(children: .contain)
+    }
+
+    private var columns: [GridItem] {
+        [GridItem(.adaptive(minimum: 140), spacing: 10)]
+    }
+
+    private var dayTitle: String {
+        LunarCalendarFormatting.dayTitle(dayNumberInMonth: day.dayNumberInMonth)
+    }
+
+    private var sealText: String {
+        String(dayTitle.suffix(1))
+    }
+
+    private var dayStemBranch: String {
+        LunarCalendarFormatting.daySubtitle(stemIndex: day.dayStemIndex, branchIndex: day.dayBranchIndex)
+    }
+
+    private var daySubtitle: String {
+        "\(dayStemBranch)日 · \(fullCivilDateTitle)"
+    }
+
+    private var lunarExpression: String {
+        "\(LunarMonthDisplay.title(for: month))\(dayTitle)"
+    }
+
+    private var civilDateFactTitle: String {
+        day.calendarDay?.civilDate?.calendarStyle == .julian ? "儒略表达" : "公历表达"
+    }
+
+    private var civilDateValue: String {
+        guard let civilDate = day.calendarDay?.civilDate else {
+            return "-"
+        }
+
+        return "\(civilDate.year).\(civilDate.month).\(civilDate.dayOfMonth)"
+    }
+
+    private var fullCivilDateTitle: String {
+        guard let civilDate = day.calendarDay?.civilDate else {
+            return "-"
+        }
+
+        let prefix = civilDate.calendarStyle == .julian ? "儒略" : "公历"
+        return "\(prefix) \(civilDate.year)年\(civilDate.month)月\(civilDate.dayOfMonth)日"
+    }
+
+    private var contentLevelTitle: String {
+        switch contentLevel {
+        case .base:
+            "基础数据"
+        case .full:
+            "完整日期数据"
+        }
+    }
+}


### PR DESCRIPTION
## Summary

This redesign turns the iOS app into the requested three-tab browsing flow so calendar browsing, historical attribution, and data settings each have a clear home. The calendar UI follows the agreed prototype and the existing domain language in CONTEXT.md.

## Changes

- Reworks the iOS tabs into 日历, 历史, and 设置, with the settings view moved into the third tab.
- Replaces the old ten-day lunar grouping with a continuous 农历月格, month arrows, month strip selection, and a selected-day detail card.
- Defaults the current lunar month/day toward today when the full date data is available, with first-day fallback.
- Updates the history tab to show ordered 朝代 cards with start/end text, emperor count, and reign era count.

## Notes

The macOS split-view layout is intentionally left unchanged. Simulator build via XcodeBuildMCP could not run because this checkout does not contain the configured `ChineseCalendar.xcodeproj`; SwiftPM validation is available and passes.

## Validation

- `swift test --package-path Sources`