### PR TITLE
Show emperor details from history

### DIFF
--- a/Sources/ChineseCalendarUI/CalendarRoute.swift
+++ b/Sources/ChineseCalendarUI/CalendarRoute.swift
@@ -3,6 +3,7 @@ import Foundation
 enum CalendarRoute: Hashable, Identifiable {
     case lunarYear(Int)
     case dynasty(String)
+    case emperor(String)
 
     var id: String {
         switch self {
@@ -10,6 +11,8 @@ enum CalendarRoute: Hashable, Identifiable {
             "lunar-year-\(yearNumber)"
         case let .dynasty(dynastyID):
             "dynasty-\(dynastyID)"
+        case let .emperor(emperorID):
+            "emperor-\(emperorID)"
         }
     }
 
@@ -17,7 +20,7 @@ enum CalendarRoute: Hashable, Identifiable {
         switch self {
         case let .lunarYear(yearNumber):
             yearNumber
-        case .dynasty:
+        case .dynasty, .emperor:
             nil
         }
     }
@@ -26,6 +29,7 @@ enum CalendarRoute: Hashable, Identifiable {
 enum CalendarDeepLink: Equatable {
     case lunarYear(Int, monthIndex: Int? = nil)
     case dynasty(String)
+    case emperor(String)
 }
 
 enum CalendarDeepLinkParser {
@@ -56,6 +60,12 @@ enum CalendarDeepLinkParser {
             }
 
             return .dynasty(parts[1])
+        case "emperor":
+            guard parts.count >= 2 else {
+                return nil
+            }
+
+            return .emperor(parts[1])
         default:
             guard let yearNumber = Int(firstPart) else {
                 return nil

--- a/Sources/ChineseCalendarUI/CalendarRouteDestinationView.swift
+++ b/Sources/ChineseCalendarUI/CalendarRouteDestinationView.swift
@@ -58,6 +58,8 @@ struct CalendarRouteDestinationView: View {
                 }
             case let .dynasty(dynastyID):
                 DynastyDetailView(dynastyID: dynastyID)
+            case let .emperor(emperorID):
+                EmperorDetailView(emperorID: emperorID)
             case nil:
                 ContentUnavailableView {
                     Label("Chinese Calendar", systemSymbol: .calendar)

--- a/Sources/ChineseCalendarUI/CalendarRouter.swift
+++ b/Sources/ChineseCalendarUI/CalendarRouter.swift
@@ -203,6 +203,10 @@ final class CalendarRouter {
             selectedTab = .history
             setPath([.dynasty(dynastyID)], for: .history)
             selectedMonthIndex = nil
+        case let .emperor(emperorID):
+            selectedTab = .history
+            setPath([.emperor(emperorID)], for: .history)
+            selectedMonthIndex = nil
         }
     }
 

--- a/Sources/ChineseCalendarUI/DynastyDetailView.swift
+++ b/Sources/ChineseCalendarUI/DynastyDetailView.swift
@@ -47,7 +47,10 @@ struct DynastyDetailView: View {
                                 .bold()
 
                             ForEach(emperors, id: \.id) { emperor in
-                                EmperorSummaryRow(emperor: emperor)
+                                NavigationLink(value: CalendarRoute.emperor(emperor.id)) {
+                                    EmperorSummaryRow(emperor: emperor)
+                                }
+                                .buttonStyle(.plain)
                             }
                         }
                     }

--- a/Sources/ChineseCalendarUI/EmperorDetailView.swift
+++ b/Sources/ChineseCalendarUI/EmperorDetailView.swift
@@ -1,0 +1,219 @@
+import ChineseCalendarPersistence
+import SFSafeSymbols
+import SwiftData
+import SwiftUI
+
+struct EmperorDetailView: View {
+    @Query private var emperors: [Emperor]
+
+    init(emperorID: String) {
+        let emperorID = emperorID
+        _emperors = Query(
+            filter: #Predicate<Emperor> { emperor in
+                emperor.id == emperorID
+            }
+        )
+    }
+
+    var body: some View {
+        if let emperor {
+            ScrollView {
+                VStack(alignment: .leading, spacing: 24) {
+                    header(for: emperor)
+
+                    LazyVGrid(columns: columns, alignment: .leading, spacing: 12) {
+                        DynastyFactCard(title: "朝代", value: emperor.dynasty.shortName ?? emperor.dynasty.name)
+                        DynastyFactCard(title: "在位", value: "\(reignSegments.count) 段")
+                        DynastyFactCard(title: "年号", value: "\(reignEras.count) 个")
+                    }
+
+                    nameSection(for: emperor)
+
+                    if !reignSegments.isEmpty {
+                        VStack(alignment: .leading, spacing: 12) {
+                            sectionTitle("在位区间")
+
+                            ForEach(reignSegments, id: \.id) { segment in
+                                reignSegmentCard(segment)
+                            }
+                        }
+                    }
+
+                    if !reignEras.isEmpty {
+                        VStack(alignment: .leading, spacing: 12) {
+                            sectionTitle("年号")
+
+                            ForEach(reignEras, id: \.id) { era in
+                                reignEraCard(era)
+                            }
+                        }
+                    }
+                }
+                .padding()
+                .frame(maxWidth: 760, alignment: .leading)
+            }
+            .navigationTitle(emperor.displayName)
+        } else {
+            ContentUnavailableView {
+                Label("没有找到皇帝", systemSymbol: .personCropCircleBadgeQuestionmark)
+            } description: {
+                Text("这个皇帝记录不在当前 SwiftData store 中。")
+            }
+        }
+    }
+
+    private var emperor: Emperor? {
+        emperors.first
+    }
+
+    private var columns: [GridItem] {
+        [GridItem(.adaptive(minimum: 140), spacing: 12)]
+    }
+
+    private var reignSegments: [EmperorReignSegment] {
+        emperor?.reignSegments.sorted {
+            ($0.sequenceIndex, $0.segmentIndex, $0.id) < ($1.sequenceIndex, $1.segmentIndex, $1.id)
+        } ?? []
+    }
+
+    private var reignEras: [ReignEra] {
+        emperor?.reignEras.sorted {
+            ($0.eraIndexWithinEmperor, $0.sequenceIndex, $0.id) < ($1.eraIndexWithinEmperor, $1.sequenceIndex, $1.id)
+        } ?? []
+    }
+
+    private func header(for emperor: Emperor) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(emperor.displayName)
+                .font(.largeTitle)
+                .bold()
+
+            Text(emperor.dynasty.name)
+                .font(.headline)
+                .foregroundStyle(.secondary)
+
+            if let note = emperor.note {
+                Text(note)
+                    .font(.callout)
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .accessibilityElement(children: .combine)
+    }
+
+    @ViewBuilder
+    private func nameSection(for emperor: Emperor) -> some View {
+        if emperor.personalName != nil || emperor.templeName != nil || emperor.posthumousName != nil {
+            VStack(alignment: .leading, spacing: 12) {
+                sectionTitle("称号")
+
+                LazyVGrid(columns: columns, alignment: .leading, spacing: 12) {
+                    if let personalName = emperor.personalName {
+                        DynastyFactCard(title: "本名", value: personalName)
+                    }
+
+                    if let templeName = emperor.templeName {
+                        DynastyFactCard(title: "庙号", value: templeName)
+                    }
+
+                    if let posthumousName = emperor.posthumousName {
+                        DynastyFactCard(title: "谥号/称号", value: posthumousName)
+                    }
+                }
+            }
+        }
+    }
+
+    private func sectionTitle(_ title: String) -> some View {
+        Text(title)
+            .font(.title2)
+            .bold()
+    }
+
+    private func reignSegmentCard(_ segment: EmperorReignSegment) -> some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text(reignSegmentTitle(segment))
+                .font(.headline)
+
+            dateLine(title: "开始", date: segment.startDate)
+            dateLine(title: "结束", date: segment.endDate)
+
+            if let note = segment.note {
+                Text(note)
+                    .font(.callout)
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding()
+        .background(.background.secondary, in: RoundedRectangle(cornerRadius: 16))
+        .accessibilityElement(children: .combine)
+    }
+
+    private func reignEraCard(_ era: ReignEra) -> some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text(era.name)
+                .font(.headline)
+
+            dateLine(title: "开始", date: era.startDate)
+            dateLine(title: "结束", date: era.endDate)
+
+            if let note = era.note {
+                Text(note)
+                    .font(.callout)
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding()
+        .background(.background.secondary, in: RoundedRectangle(cornerRadius: 16))
+        .accessibilityElement(children: .combine)
+    }
+
+    private func dateLine(title: String, date: ChineseDateExpression) -> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(title)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+
+            Text(date.sourceText)
+                .font(.subheadline)
+
+            Text(precisionText(for: date))
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private func reignSegmentTitle(_ segment: EmperorReignSegment) -> String {
+        guard let segmentName = segment.segmentName else {
+            return "第 \(segment.segmentIndex + 1) 段在位"
+        }
+
+        return segmentName
+    }
+
+    private func precisionText(for date: ChineseDateExpression) -> String {
+        switch date.precision {
+        case .year:
+            indexText(prefix: "年精度", date: date)
+        case .month:
+            indexText(prefix: "月精度", date: date)
+        case .day:
+            indexText(prefix: "日精度", date: date)
+        case .range:
+            "范围精度"
+        case .unknown:
+            "精度未知"
+        }
+    }
+
+    private func indexText(prefix: String, date: ChineseDateExpression) -> String {
+        guard let index = date.index else {
+            return prefix
+        }
+
+        return "\(prefix) · index \(index)"
+    }
+}

--- a/Sources/ChineseCalendarUI/EmperorSummaryRow.swift
+++ b/Sources/ChineseCalendarUI/EmperorSummaryRow.swift
@@ -1,17 +1,27 @@
 import ChineseCalendarPersistence
+import SFSafeSymbols
 import SwiftUI
 
 struct EmperorSummaryRow: View {
     let emperor: Emperor
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 4) {
-            Text(emperor.displayName)
-                .font(.headline)
+        HStack(spacing: 12) {
+            VStack(alignment: .leading, spacing: 4) {
+                Text(emperor.displayName)
+                    .font(.headline)
 
-            Text(subtitle)
-                .font(.subheadline)
-                .foregroundStyle(.secondary)
+                Text(subtitle)
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+            }
+
+            Spacer(minLength: 12)
+
+            Image(systemSymbol: .chevronRight)
+                .font(.footnote)
+                .foregroundStyle(.tertiary)
+                .accessibilityHidden(true)
         }
         .frame(maxWidth: .infinity, alignment: .leading)
         .padding()

--- a/Sources/ChineseCalendarUI/Tests/CalendarRouterTests.swift
+++ b/Sources/ChineseCalendarUI/Tests/CalendarRouterTests.swift
@@ -164,6 +164,17 @@ import Testing
     #expect(router.selectedMonthIndex == nil)
 }
 
+@MainActor
+@Test func emperorDeepLinkSelectsHistoryTab() {
+    let router = CalendarRouter()
+
+    router.openColdLaunchDeepLink(.emperor("ming-taizu"))
+
+    #expect(router.selectedTab == .history)
+    #expect(router.historyPath == [.emperor("ming-taizu")])
+    #expect(router.selectedMonthIndex == nil)
+}
+
 @Test func parserSupportsYearURLs() throws {
     let url = try #require(URL(string: "chinesecalendar://year/2026?monthIndex=26001"))
 
@@ -174,6 +185,12 @@ import Testing
     let url = try #require(URL(string: "chinesecalendar://dynasty/qin"))
 
     #expect(CalendarDeepLinkParser.deepLink(from: url) == .dynasty("qin"))
+}
+
+@Test func parserSupportsEmperorURLs() throws {
+    let url = try #require(URL(string: "chinesecalendar://emperor/ming-taizu"))
+
+    #expect(CalendarDeepLinkParser.deepLink(from: url) == .emperor("ming-taizu"))
 }
 
 @Test func parserSupportsLaunchArguments() {


### PR DESCRIPTION
## Summary
- Add emperor detail routing and destination view
- Make emperor rows navigable from dynasty details
- Cover emperor deep links in router tests

## Tests
- swift test --package-path Sources