### PR TITLE
Add color scheme setting

### DIFF
--- a/Sources/ChineseCalendarUI/CalendarColorSchemePreference.swift
+++ b/Sources/ChineseCalendarUI/CalendarColorSchemePreference.swift
@@ -1,0 +1,50 @@
+import SwiftUI
+
+enum CalendarColorSchemePreference: String, CaseIterable, Identifiable {
+    case system
+    case light
+    case dark
+
+    static let storageKey = "calendarColorSchemePreference"
+
+    var id: Self {
+        self
+    }
+
+    var title: String {
+        switch self {
+        case .system:
+            "跟随系统"
+        case .light:
+            "浅色"
+        case .dark:
+            "深色"
+        }
+    }
+
+    var colorScheme: ColorScheme? {
+        switch self {
+        case .system:
+            nil
+        case .light:
+            .light
+        case .dark:
+            .dark
+        }
+    }
+}
+
+struct CalendarColorSchemePreferenceModifier: ViewModifier {
+    @AppStorage(CalendarColorSchemePreference.storageKey)
+    private var colorSchemePreference = CalendarColorSchemePreference.system
+
+    func body(content: Content) -> some View {
+        content.preferredColorScheme(colorSchemePreference.colorScheme)
+    }
+}
+
+extension View {
+    func calendarColorSchemePreference() -> some View {
+        modifier(CalendarColorSchemePreferenceModifier())
+    }
+}

--- a/Sources/ChineseCalendarUI/CalendarSettingsView.swift
+++ b/Sources/ChineseCalendarUI/CalendarSettingsView.swift
@@ -7,6 +7,8 @@ public struct CalendarSettingsView: View {
     private let showsDoneButton: Bool
 
     @Environment(\.dismiss) private var dismiss
+    @AppStorage(CalendarColorSchemePreference.storageKey)
+    private var colorSchemePreference = CalendarColorSchemePreference.system
     @State private var isConfirmingClear = false
     @State private var resultMessage: SettingsResultMessage?
 
@@ -17,6 +19,15 @@ public struct CalendarSettingsView: View {
 
     public var body: some View {
         Form {
+            Section("外观") {
+                Picker("颜色模式", selection: $colorSchemePreference) {
+                    ForEach(CalendarColorSchemePreference.allCases) { preference in
+                        Text(preference.title)
+                            .tag(preference)
+                    }
+                }
+            }
+
             Section("数据") {
                 VStack(alignment: .leading, spacing: 6) {
                     Label(dataStatusTitle, systemSymbol: dataStatusSystemSymbol)
@@ -71,6 +82,7 @@ public struct CalendarSettingsView: View {
         } message: { resultMessage in
             Text(resultMessage.message)
         }
+        .calendarColorSchemePreference()
     }
 
     private var resultMessageIsPresented: Binding<Bool> {

--- a/Sources/ChineseCalendarUI/ChineseCalendarRootView.swift
+++ b/Sources/ChineseCalendarUI/ChineseCalendarRootView.swift
@@ -43,6 +43,7 @@ public struct ChineseCalendarRootView: View {
         } message: {
             Text(coordinator.downloadErrorMessage ?? "请稍后再试。")
         }
+        .calendarColorSchemePreference()
     }
 
     @ViewBuilder

--- a/Sources/ChineseCalendarUI/FullStoreDownloadProgressViews.swift
+++ b/Sources/ChineseCalendarUI/FullStoreDownloadProgressViews.swift
@@ -28,6 +28,7 @@ public struct FullStoreDownloadProgressWindow: View {
             }
         }
         .frame(minWidth: 360, idealWidth: 420, minHeight: 180, idealHeight: 220)
+        .calendarColorSchemePreference()
     }
 }
 


### PR DESCRIPTION
## Summary
- Add a persisted color scheme preference with system, light, and dark options
- Surface the preference in Settings under 外观 / 颜色模式
- Apply the preference to the main app UI and macOS download progress window

## Tests
- `swift test --package-path Sources`
- `xcodebuild -project ChineseCalendar.xcodeproj -scheme ChineseCalendar-iOS -destination 'id=1B15591D-3AA6-444E-A025-F3CF34308855' build`