### PR TITLE
Fix month switcher visibility

### DIFF
--- a/Sources/ChineseCalendarUI/MonthSwitcher.swift
+++ b/Sources/ChineseCalendarUI/MonthSwitcher.swift
@@ -15,6 +15,8 @@ struct MonthSwitcher: View {
     let selectNextMonth: () -> Void
     let selectMonth: (ChineseLunarMonth) -> Void
 
+    @State private var scrollPosition: Int?
+
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {
             HStack(alignment: .center, spacing: 10) {
@@ -44,23 +46,25 @@ struct MonthSwitcher: View {
                         Button {
                             selectMonth(month)
                         } label: {
-                            VStack(spacing: 4) {
-                                Text(LunarMonthDisplay.title(for: month))
-                                Text("\(month.dayCount)天")
-                                    .font(.caption)
-                                    .foregroundStyle(.secondary)
-                            }
-                            .padding(.horizontal, 12)
-                            .padding(.vertical, 8)
-                            .frame(minWidth: 76)
+                            Text(LunarMonthDisplay.title(for: month))
+                                .padding(.horizontal, 12)
+                                .padding(.vertical, 8)
+                                .frame(minWidth: 76, minHeight: 44)
                         }
+                        .id(month.lunarMonthIndex)
                         .buttonStyle(.bordered)
                         .controlSize(.regular)
                         .tint(month.lunarMonthIndex == selectedMonth.lunarMonthIndex ? .accentColor : nil)
                     }
                 }
+                .scrollTargetLayout()
             }
             .scrollIndicators(.hidden)
+            .scrollPosition(id: $scrollPosition, anchor: .center)
+            .onAppear(perform: scrollToSelectedMonth)
+            .onChange(of: selectedMonth.lunarMonthIndex) {
+                scrollToSelectedMonth()
+            }
         }
     }
 
@@ -88,5 +92,9 @@ struct MonthSwitcher: View {
                 .foregroundStyle(.secondary)
         }
         .accessibilityElement(children: .combine)
+    }
+
+    private func scrollToSelectedMonth() {
+        scrollPosition = selectedMonth.lunarMonthIndex
     }
 }


### PR DESCRIPTION
## Summary
- Hide duplicate day-count text from month switcher pills
- Keep the selected month visible by centering the horizontal scroll position

Fixes #65

## Tests
- swift test --package-path Sources
- xcodebuild -project ChineseCalendar.xcodeproj -scheme ChineseCalendar-iOS -destination id=1B15591D-3AA6-444E-A025-F3CF34308855 -disableAutomaticPackageResolution -onlyUsePackageVersionsFromResolvedFile build -quiet
- xcodebuild -project ChineseCalendar.xcodeproj -scheme ChineseCalendar-macOS -destination platform=macOS -disableAutomaticPackageResolution -onlyUsePackageVersionsFromResolvedFile build -quiet