### PR TITLE
Improve selected date readability

### DIFF
--- a/Sources/ChineseCalendarUI/LunarDayGridCell.swift
+++ b/Sources/ChineseCalendarUI/LunarDayGridCell.swift
@@ -28,27 +28,26 @@ struct LunarDayGridCell: View {
 
             Text(daySubtitle)
                 .font(.subheadline)
-                .foregroundStyle(isSelected ? Color.white.opacity(0.82) : Color.secondary)
+                .foregroundStyle(isSelected ? Color.white.opacity(0.92) : Color.secondary)
 
             Text(civilDateTitle)
                 .font(.subheadline)
-                .foregroundStyle(isSelected ? Color.white.opacity(0.66) : Color.secondary)
+                .foregroundStyle(isSelected ? Color.white.opacity(0.84) : Color.secondary)
         }
         .foregroundStyle(isSelected ? Color.white : Color.primary)
         .padding(10)
         .frame(maxWidth: .infinity, minHeight: 72, alignment: .topLeading)
-        .background(.background, in: RoundedRectangle(cornerRadius: 18))
         .background {
-            if isSelected {
-                RoundedRectangle(cornerRadius: 18)
-                    .fill(Color.accentColor)
-            }
+            RoundedRectangle(cornerRadius: 18)
+                .fill(isSelected ? Color.accentColor : Color.clear)
         }
+        .background(.background, in: RoundedRectangle(cornerRadius: 18))
         .overlay {
             RoundedRectangle(cornerRadius: 18)
-                .stroke(isToday && !isSelected ? Color.accentColor : Color.primary.opacity(0.08))
+                .strokeBorder(borderColor, lineWidth: borderWidth)
         }
         .accessibilityElement(children: .combine)
+        .accessibilityAddTraits(isSelected ? .isSelected : [])
     }
 
     private var dayTitle: String {
@@ -70,5 +69,21 @@ struct LunarDayGridCell: View {
             dayOfMonth: civilDate.dayOfMonth,
             isJulianCalendar: civilDate.calendarStyle == .julian
         )
+    }
+
+    private var borderColor: Color {
+        if isSelected {
+            return Color.white.opacity(0.72)
+        }
+
+        if isToday {
+            return Color.accentColor
+        }
+
+        return Color.primary.opacity(0.08)
+    }
+
+    private var borderWidth: CGFloat {
+        isSelected || isToday ? 1.5 : 1
     }
 }


### PR DESCRIPTION
## Summary
- Fix selected lunar day cells so the accent selection fill remains visible instead of being covered by the system background.
- Increase selected-state secondary text contrast and strengthen selected/today borders.
- Add the selected accessibility trait for the active date cell.

Fixes #64

## Validation
- `swift test --package-path Sources`
- `xcodebuild -project ChineseCalendar.xcodeproj -scheme ChineseCalendar-iOS -destination 'platform=iOS Simulator,id=1B15591D-3AA6-444E-A025-F3CF34308855' -derivedDataPath /tmp/ChineseCalendarDerivedData-ios -quiet build`
- `xcodebuild -project ChineseCalendar.xcodeproj -scheme ChineseCalendar-macOS -destination 'platform=macOS,arch=arm64' -derivedDataPath /tmp/ChineseCalendarDerivedData-macos -quiet build`