### PR TITLE
Optimize lunar month switching

### DIFF
--- a/Sources/ChineseCalendarUI/CalendarHomeSplitView.swift
+++ b/Sources/ChineseCalendarUI/CalendarHomeSplitView.swift
@@ -9,6 +9,9 @@ struct CalendarHomeSplitView: View {
     let emptyStateDescription: String
 
     var body: some View {
+        let yearsRoute = router.currentRoute(on: .years)
+        let yearNumbers = years.map(\.lunarYearNumber)
+
         NavigationSplitView {
             List(selection: selection) {
                 Section("农历年") {
@@ -21,8 +24,8 @@ struct CalendarHomeSplitView: View {
             .navigationTitle("年份")
         } detail: {
             CalendarRouteDestinationView(
-                route: router.currentRoute(on: .years),
-                year: selectedYear,
+                route: yearsRoute,
+                year: year(for: yearsRoute),
                 months: months,
                 selectedMonthIndex: $router.selectedMonthIndex,
                 selectedDayIndex: $router.selectedDayIndex,
@@ -54,15 +57,11 @@ struct CalendarHomeSplitView: View {
         }
     }
 
-    private var yearNumbers: [Int] {
-        years.map(\.lunarYearNumber)
-    }
-
-    private var selectedYear: ChineseLunarYear? {
-        guard let selectedYearNumber = router.selectedYearNumber else {
+    private func year(for route: CalendarRoute?) -> ChineseLunarYear? {
+        guard let yearNumber = route?.lunarYearNumber else {
             return nil
         }
 
-        return years.first { $0.lunarYearNumber == selectedYearNumber }
+        return years.first { $0.lunarYearNumber == yearNumber }
     }
 }

--- a/Sources/ChineseCalendarUI/CalendarHomeTabView.swift
+++ b/Sources/ChineseCalendarUI/CalendarHomeTabView.swift
@@ -13,11 +13,15 @@ struct CalendarHomeTabView<BottomStatusBar: View>: View {
     let bottomStatusBar: () -> BottomStatusBar
 
     var body: some View {
+        let yearsRoute = router.currentRoute(on: .years)
+        let yearNumbers = years.map(\.lunarYearNumber)
+
         TabView(selection: $router.selectedTab) {
             NavigationStack {
                 calendarDestination(
-                    for: router.currentRoute(on: .years),
-                    year: selectedYear
+                    for: yearsRoute,
+                    year: year(for: yearsRoute),
+                    yearNumbers: yearNumbers
                 )
             }
             .safeAreaInset(edge: .bottom, spacing: 0, content: bottomStatusBar)
@@ -28,7 +32,9 @@ struct CalendarHomeTabView<BottomStatusBar: View>: View {
 
             NavigationStack(path: $router.historyPath) {
                 CalendarHistoryHomeView()
-                    .navigationDestination(for: CalendarRoute.self, destination: destination)
+                    .navigationDestination(for: CalendarRoute.self) { route in
+                        calendarDestination(for: route, year: year(for: route), yearNumbers: yearNumbers)
+                    }
             }
             .safeAreaInset(edge: .bottom, spacing: 0, content: bottomStatusBar)
             .tabItem {
@@ -56,11 +62,11 @@ struct CalendarHomeTabView<BottomStatusBar: View>: View {
         .background(.calendarSystemBackground)
     }
 
-    private func destination(for route: CalendarRoute) -> some View {
-        calendarDestination(for: route, year: year(for: route))
-    }
-
-    private func calendarDestination(for route: CalendarRoute?, year: ChineseLunarYear?) -> some View {
+    private func calendarDestination(
+        for route: CalendarRoute?,
+        year: ChineseLunarYear?,
+        yearNumbers: [Int]
+    ) -> some View {
         CalendarRouteDestinationView(
             route: route,
             year: year,
@@ -86,19 +92,11 @@ struct CalendarHomeTabView<BottomStatusBar: View>: View {
         )
     }
 
-    private var yearNumbers: [Int] {
-        years.map(\.lunarYearNumber)
-    }
-
     private func year(for route: CalendarRoute?) -> ChineseLunarYear? {
         guard let yearNumber = route?.lunarYearNumber else {
             return nil
         }
 
         return years.first { $0.lunarYearNumber == yearNumber }
-    }
-
-    private var selectedYear: ChineseLunarYear? {
-        year(for: router.currentRoute(on: .years))
     }
 }

--- a/Sources/ChineseCalendarUI/LunarYearDetailView.swift
+++ b/Sources/ChineseCalendarUI/LunarYearDetailView.swift
@@ -88,6 +88,8 @@ struct LunarYearDetailView: View {
     }
 
     var body: some View {
+        let adjacentMonths = adjacentCalendarMonths
+
         ScrollView {
             VStack(alignment: .leading, spacing: 24) {
                 if monthsInYearStartOrder.isEmpty {
@@ -101,13 +103,12 @@ struct LunarYearDetailView: View {
                         month: selectedMonth,
                         selectedDayIndex: $selectedDayIndex,
                         showYearPicker: showYearPicker,
-                        canSelectPreviousMonth: canSelectPreviousMonth,
-                        canSelectNextMonth: canSelectNextMonth,
-                        selectPreviousMonth: selectPreviousMonth,
-                        selectNextMonth: selectNextMonth,
+                        canSelectPreviousMonth: canSelect(adjacentMonths.previous),
+                        canSelectNextMonth: canSelect(adjacentMonths.next),
+                        selectPreviousMonth: { selectMonthInCalendar(adjacentMonths.previous) },
+                        selectNextMonth: { selectMonthInCalendar(adjacentMonths.next) },
                         selectMonth: selectMonthInCalendar
                     )
-                    .id(selectedMonth.lunarMonthIndex)
                 }
             }
             .padding()
@@ -208,40 +209,33 @@ struct LunarYearDetailView: View {
         calendarMonths
     }
 
-    private var selectedMonthInCalendarIndex: [ChineseLunarMonth].Index? {
+    private var adjacentCalendarMonths: (previous: ChineseLunarMonth?, next: ChineseLunarMonth?) {
         guard let selectedMonth else {
-            return nil
+            return (nil, nil)
         }
 
-        return calendarMonthsInOrder.firstIndex { $0.lunarMonthIndex == selectedMonth.lunarMonthIndex }
-    }
-
-    private var previousCalendarMonth: ChineseLunarMonth? {
-        guard let selectedMonthInCalendarIndex,
-              selectedMonthInCalendarIndex > calendarMonthsInOrder.startIndex
+        guard let selectedMonthInCalendarIndex = calendarMonthsInOrder.firstIndex(where: {
+            $0.lunarMonthIndex == selectedMonth.lunarMonthIndex
+        })
         else {
-            return nil
+            return (nil, nil)
         }
 
-        return calendarMonthsInOrder[calendarMonthsInOrder.index(before: selectedMonthInCalendarIndex)]
-    }
-
-    private var nextCalendarMonth: ChineseLunarMonth? {
-        guard let selectedMonthInCalendarIndex,
-              selectedMonthInCalendarIndex < calendarMonthsInOrder.index(before: calendarMonthsInOrder.endIndex)
-        else {
-            return nil
+        let previousMonth: ChineseLunarMonth?
+        if selectedMonthInCalendarIndex > calendarMonthsInOrder.startIndex {
+            previousMonth = calendarMonthsInOrder[calendarMonthsInOrder.index(before: selectedMonthInCalendarIndex)]
+        } else {
+            previousMonth = nil
         }
 
-        return calendarMonthsInOrder[calendarMonthsInOrder.index(after: selectedMonthInCalendarIndex)]
-    }
+        let nextMonth: ChineseLunarMonth?
+        if selectedMonthInCalendarIndex < calendarMonthsInOrder.index(before: calendarMonthsInOrder.endIndex) {
+            nextMonth = calendarMonthsInOrder[calendarMonthsInOrder.index(after: selectedMonthInCalendarIndex)]
+        } else {
+            nextMonth = nil
+        }
 
-    private var canSelectPreviousMonth: Bool {
-        canSelect(previousCalendarMonth)
-    }
-
-    private var canSelectNextMonth: Bool {
-        canSelect(nextCalendarMonth)
+        return (previousMonth, nextMonth)
     }
 
     private func canSelect(_ month: ChineseLunarMonth?) -> Bool {
@@ -252,31 +246,27 @@ struct LunarYearDetailView: View {
         return month.lunarYearNumber == year.lunarYearNumber || selectMonth != nil
     }
 
-    private func selectPreviousMonth() {
-        guard let previousCalendarMonth else {
-            return
-        }
-
-        selectMonthInCalendar(previousCalendarMonth)
-    }
-
-    private func selectNextMonth() {
-        guard let nextCalendarMonth else {
-            return
-        }
-
-        selectMonthInCalendar(nextCalendarMonth)
-    }
-
     private func selectMonthInCalendar(_ month: ChineseLunarMonth) {
         if month.lunarYearNumber == year.lunarYearNumber {
-            if selectedMonthIndex != month.lunarMonthIndex {
+            guard selectedMonthIndex != month.lunarMonthIndex else {
+                return
+            }
+
+            selectedMonthIndex = month.lunarMonthIndex
+            if selectedDayIndex != nil {
                 selectedDayIndex = nil
             }
-            selectedMonthIndex = month.lunarMonthIndex
         } else {
             selectMonth?(month)
         }
+    }
+
+    private func selectMonthInCalendar(_ month: ChineseLunarMonth?) {
+        guard let month else {
+            return
+        }
+
+        selectMonthInCalendar(month)
     }
 
     private func selectTodayFromToolbar() {


### PR DESCRIPTION
## Summary
- Avoid forcing the lunar month detail subtree to recreate on every month switch
- Reuse computed adjacent month values for arrow availability and actions
- Reduce repeated route/year derivation in calendar home containers

## Validation
- `GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=safe.bareRepository GIT_CONFIG_VALUE_0=all swift test --package-path Sources`
- XcodeBuildMCP iOS Simulator build for `ChineseCalendar-iOS`