### PR TITLE
Optimize lunar month switching

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,6 +72,33 @@ This repository hosts a Swift project for browsing the traditional Chinese calen
 - If active defaults are missing or differ from `.xcodebuildmcp/config.yaml`, read `sessionDefaults` from that file and apply them with `session_set_defaults` before building, running, or testing.
 - Resolve any relative `projectPath` in `sessionDefaults` from the repository root before calling `session_set_defaults` (for example, `ChineseCalendar.xcodeproj` becomes `<repo-root>/ChineseCalendar.xcodeproj`).
 
+## Simulator in Codex Browser
+
+- When the user asks to view or operate the running iOS app in the Codex in-app browser, use the `ios-simulator-browser` skill together with the in-app browser skill.
+- Use the simulator selected by XcodeBuildMCP. Read `sessionDefaults.simulatorId` from `.xcodebuildmcp/config.yaml` when session-default tools are unavailable; do not choose a different booted simulator by name.
+- `serve-sim` must run without inherited proxy variables. A proxy-launched process can capture the framebuffer while the browser remains at `Connecting...` or reports `control socket connect timeout`. If the package is not cached yet, fetch/cache it in a separate command using the repository's required full proxy environment, then start the actual mirror offline with all proxy variables removed.
+- Start a simulator-scoped, long-running mirror and keep its terminal alive while the browser is using it. Never use an unscoped `serve-sim --kill`:
+
+  ```bash
+  SIM="<sessionDefaults.simulatorId>"
+  cleanup_serve_sim() {
+    env -u HTTP_PROXY -u HTTPS_PROXY -u ALL_PROXY \
+      -u http_proxy -u https_proxy -u all_proxy \
+      -u NO_PROXY -u no_proxy \
+      npx --offline --yes serve-sim@latest --kill "$SIM" >/dev/null 2>&1 || true
+  }
+  trap cleanup_serve_sim EXIT INT TERM HUP
+  cleanup_serve_sim
+  env -u HTTP_PROXY -u HTTPS_PROXY -u ALL_PROXY \
+    -u http_proxy -u https_proxy -u all_proxy \
+    -u NO_PROXY -u no_proxy \
+    npx --offline --yes serve-sim@latest "$SIM"
+  ```
+
+- Open the exact local URL printed by `serve-sim` (normally `http://localhost:3200`) in the Codex in-app browser. Do not report success until the status is `live`, a real app frame is visible, and one simulator interaction such as switching tabs has visibly changed the app.
+- If the in-app browser reports that its webview did not attach, keep the existing browser binding, create a fresh tab, and retry the local URL. Navigation can replace the browser tab ID; if a later action says the tab is missing, list tabs and reacquire the current `Simulator - <device name>` tab instead of restarting the simulator mirror.
+- If `serve-sim` shows `Connecting...`, inspect its terminal. Framebuffer/encoder-ready messages prove capture started but not that the control socket is usable. Restart the mirror with the proxy variables removed as above; after it becomes `live`, browser coordinate clicks can operate the streamed simulator UI.
+
 ## Swift Agent Guidance
 
 The project keeps its own repository-specific rules above, but also adopts the spirit of Paul Hudson's Swift agent guidance:

--- a/Sources/ChineseCalendarUI/LunarYearDetailView.swift
+++ b/Sources/ChineseCalendarUI/LunarYearDetailView.swift
@@ -88,6 +88,8 @@ struct LunarYearDetailView: View {
     }
 
     var body: some View {
+        let adjacentMonths = adjacentCalendarMonths
+
         ScrollView {
             VStack(alignment: .leading, spacing: 24) {
                 if monthsInYearStartOrder.isEmpty {
@@ -101,13 +103,12 @@ struct LunarYearDetailView: View {
                         month: selectedMonth,
                         selectedDayIndex: $selectedDayIndex,
                         showYearPicker: showYearPicker,
-                        canSelectPreviousMonth: canSelectPreviousMonth,
-                        canSelectNextMonth: canSelectNextMonth,
-                        selectPreviousMonth: selectPreviousMonth,
-                        selectNextMonth: selectNextMonth,
+                        canSelectPreviousMonth: canSelect(adjacentMonths.previous),
+                        canSelectNextMonth: canSelect(adjacentMonths.next),
+                        selectPreviousMonth: { selectMonthInCalendar(adjacentMonths.previous) },
+                        selectNextMonth: { selectMonthInCalendar(adjacentMonths.next) },
                         selectMonth: selectMonthInCalendar
                     )
-                    .id(selectedMonth.lunarMonthIndex)
                 }
             }
             .padding()
@@ -208,40 +209,33 @@ struct LunarYearDetailView: View {
         calendarMonths
     }
 
-    private var selectedMonthInCalendarIndex: [ChineseLunarMonth].Index? {
+    private var adjacentCalendarMonths: (previous: ChineseLunarMonth?, next: ChineseLunarMonth?) {
         guard let selectedMonth else {
-            return nil
+            return (nil, nil)
         }
 
-        return calendarMonthsInOrder.firstIndex { $0.lunarMonthIndex == selectedMonth.lunarMonthIndex }
-    }
-
-    private var previousCalendarMonth: ChineseLunarMonth? {
-        guard let selectedMonthInCalendarIndex,
-              selectedMonthInCalendarIndex > calendarMonthsInOrder.startIndex
+        guard let selectedMonthInCalendarIndex = calendarMonthsInOrder.firstIndex(where: {
+            $0.lunarMonthIndex == selectedMonth.lunarMonthIndex
+        })
         else {
-            return nil
+            return (nil, nil)
         }
 
-        return calendarMonthsInOrder[calendarMonthsInOrder.index(before: selectedMonthInCalendarIndex)]
-    }
-
-    private var nextCalendarMonth: ChineseLunarMonth? {
-        guard let selectedMonthInCalendarIndex,
-              selectedMonthInCalendarIndex < calendarMonthsInOrder.index(before: calendarMonthsInOrder.endIndex)
-        else {
-            return nil
+        let previousMonth: ChineseLunarMonth?
+        if selectedMonthInCalendarIndex > calendarMonthsInOrder.startIndex {
+            previousMonth = calendarMonthsInOrder[calendarMonthsInOrder.index(before: selectedMonthInCalendarIndex)]
+        } else {
+            previousMonth = nil
         }
 
-        return calendarMonthsInOrder[calendarMonthsInOrder.index(after: selectedMonthInCalendarIndex)]
-    }
+        let nextMonth: ChineseLunarMonth?
+        if selectedMonthInCalendarIndex < calendarMonthsInOrder.index(before: calendarMonthsInOrder.endIndex) {
+            nextMonth = calendarMonthsInOrder[calendarMonthsInOrder.index(after: selectedMonthInCalendarIndex)]
+        } else {
+            nextMonth = nil
+        }
 
-    private var canSelectPreviousMonth: Bool {
-        canSelect(previousCalendarMonth)
-    }
-
-    private var canSelectNextMonth: Bool {
-        canSelect(nextCalendarMonth)
+        return (previousMonth, nextMonth)
     }
 
     private func canSelect(_ month: ChineseLunarMonth?) -> Bool {
@@ -252,31 +246,27 @@ struct LunarYearDetailView: View {
         return month.lunarYearNumber == year.lunarYearNumber || selectMonth != nil
     }
 
-    private func selectPreviousMonth() {
-        guard let previousCalendarMonth else {
-            return
-        }
-
-        selectMonthInCalendar(previousCalendarMonth)
-    }
-
-    private func selectNextMonth() {
-        guard let nextCalendarMonth else {
-            return
-        }
-
-        selectMonthInCalendar(nextCalendarMonth)
-    }
-
     private func selectMonthInCalendar(_ month: ChineseLunarMonth) {
         if month.lunarYearNumber == year.lunarYearNumber {
-            if selectedMonthIndex != month.lunarMonthIndex {
+            guard selectedMonthIndex != month.lunarMonthIndex else {
+                return
+            }
+
+            selectedMonthIndex = month.lunarMonthIndex
+            if selectedDayIndex != nil {
                 selectedDayIndex = nil
             }
-            selectedMonthIndex = month.lunarMonthIndex
         } else {
             selectMonth?(month)
         }
+    }
+
+    private func selectMonthInCalendar(_ month: ChineseLunarMonth?) {
+        guard let month else {
+            return
+        }
+
+        selectMonthInCalendar(month)
     }
 
     private func selectTodayFromToolbar() {


### PR DESCRIPTION
## Summary
- preserve the month switcher view identity while changing lunar months
- avoid redundant adjacent-month lookups and repeated current-month selection updates
- document the verified Codex in-app simulator browser workflow

## Verification
- `swift test --package-path Sources` (48 tests passed)
- XcodeBuildMCP Debug build and run on `chinesedate iPhone 17 Pro Max`
- verified 9月 → 10月 and rapid 8月 → 10月 switching in Simulator