### PR TITLE
年份选择器打开时定位到当前年份

### DIFF
--- a/Sources/ChineseCalendarUI/Calendar/Years/CalendarYearPickerView.swift
+++ b/Sources/ChineseCalendarUI/Calendar/Years/CalendarYearPickerView.swift
@@ -8,32 +8,79 @@ struct CalendarYearPickerView: View {
     let selectedYearNumber: Int?
     let selectYear: (Int) -> Void
 
+    @State private var hasResolvedInitialScrollTarget = false
+
     var body: some View {
-        List {
-            Section("农历年") {
-                ForEach(years, id: \.lunarYearNumber) { year in
-                    Button {
-                        selectYear(year.lunarYearNumber)
-                    } label: {
-                        HStack(spacing: 12) {
-                            LunarYearRow(year: year)
+        ScrollViewReader { proxy in
+            List {
+                Section("农历年") {
+                    ForEach(years, id: \.lunarYearNumber) { year in
+                        Button {
+                            selectYear(year.lunarYearNumber)
+                        } label: {
+                            HStack(spacing: 12) {
+                                LunarYearRow(year: year)
 
-                            Spacer()
+                                Spacer()
 
-                            if year.lunarYearNumber == selectedYearNumber {
-                                Image(systemSymbol: .checkmark)
-                                    .font(.headline)
-                                    .foregroundStyle(.tint)
-                                    .accessibilityHidden(true)
+                                if year.lunarYearNumber == selectedYearNumber {
+                                    Image(systemSymbol: .checkmark)
+                                        .font(.headline)
+                                        .foregroundStyle(.tint)
+                                        .accessibilityHidden(true)
+                                }
                             }
+                            .contentShape(Rectangle())
                         }
-                        .contentShape(Rectangle())
+                        .buttonStyle(.plain)
+                        .id(year.lunarYearNumber)
+                        .accessibilityAddTraits(year.lunarYearNumber == selectedYearNumber ? .isSelected : [])
                     }
-                    .buttonStyle(.plain)
-                    .accessibilityAddTraits(year.lunarYearNumber == selectedYearNumber ? .isSelected : [])
                 }
+            }
+            .onChange(of: years.map(\.lunarYearNumber), initial: true) {
+                positionInitiallyIfNeeded(using: proxy)
             }
         }
         .navigationTitle("年份选择器")
+    }
+
+    static func initialScrollTarget(
+        selectedYearNumber: Int?,
+        availableYearNumbers: [Int]
+    ) -> Int? {
+        guard let selectedYearNumber,
+              availableYearNumbers.contains(selectedYearNumber)
+        else {
+            return nil
+        }
+
+        return selectedYearNumber
+    }
+
+    private func positionInitiallyIfNeeded(using proxy: ScrollViewProxy) {
+        guard !hasResolvedInitialScrollTarget else {
+            return
+        }
+
+        guard selectedYearNumber != nil else {
+            hasResolvedInitialScrollTarget = true
+            return
+        }
+
+        let availableYearNumbers = years.map(\.lunarYearNumber)
+        guard !availableYearNumbers.isEmpty else {
+            return
+        }
+
+        hasResolvedInitialScrollTarget = true
+        guard let target = Self.initialScrollTarget(
+            selectedYearNumber: selectedYearNumber,
+            availableYearNumbers: availableYearNumbers
+        ) else {
+            return
+        }
+
+        proxy.scrollTo(target, anchor: .center)
     }
 }

--- a/Sources/ChineseCalendarUI/Tests/CalendarYearPickerViewTests.swift
+++ b/Sources/ChineseCalendarUI/Tests/CalendarYearPickerViewTests.swift
@@ -1,0 +1,29 @@
+@testable import ChineseCalendarUI
+import Testing
+
+@Test func yearPickerInitialScrollTargetFindsSelectedYear() {
+    let target = CalendarYearPickerView.initialScrollTarget(
+        selectedYearNumber: 2026,
+        availableYearNumbers: [2024, 2025, 2026, 2027]
+    )
+
+    #expect(target == 2026)
+}
+
+@Test func yearPickerInitialScrollTargetIsNilWithoutSelection() {
+    let target = CalendarYearPickerView.initialScrollTarget(
+        selectedYearNumber: nil,
+        availableYearNumbers: [2024, 2025, 2026]
+    )
+
+    #expect(target == nil)
+}
+
+@Test func yearPickerInitialScrollTargetIsNilWhenSelectionIsUnavailable() {
+    let target = CalendarYearPickerView.initialScrollTarget(
+        selectedYearNumber: 1900,
+        availableYearNumbers: [2024, 2025, 2026]
+    )
+
+    #expect(target == nil)
+}


### PR DESCRIPTION
## Summary

- 等待年份数据首次可用后，将年份选择器定位到当前选中年份并尽量居中
- 初始定位只执行一次，后续数据更新和用户手动滚动不会反复跳转
- 对空选择或数据集中不存在的年份保持默认位置
- 保留当前年份勾选和 VoiceOver `isSelected` 语义
- 补充初始目标年份解析测试

## Verification

- XcodeBuildMCP iOS Simulator tests: 57 passed, 0 failed
- XcodeBuildMCP build and run: succeeded on chinesedate iPhone 17 Pro Max
- XcodeBuildMCP Swift package build: succeeded
- 手工验证 2026 首次打开定位在 2019–2032 可见范围中部
- 手动滚动至 2030–2042 后未发生回跳
- 选择 2040 后再次打开，定位在 2033–2046 可见范围中部
- SwiftFormat and SwiftLint: passed

Fixes #79