### PR TITLE
移除月份副标题中的默认选择策略文案

### DIFF
--- a/Sources/ChineseCalendarUI/Calendar/YearDetail/Month/LunarMonthGrid.swift
+++ b/Sources/ChineseCalendarUI/Calendar/YearDetail/Month/LunarMonthGrid.swift
@@ -72,7 +72,7 @@ struct LunarMonthGrid: View {
         VStack(alignment: .leading, spacing: 16) {
             MonthSwitcher(
                 title: monthNavigationTitle,
-                subtitle: monthNavigationSubtitle(defaultsToToday: todayDay != nil),
+                subtitle: monthNavigationSubtitle,
                 months: months,
                 selectedMonth: month,
                 showYearPicker: showYearPicker,
@@ -167,16 +167,15 @@ struct LunarMonthGrid: View {
         return "\(yearTitle) \(LunarMonthDisplay.title(for: month))"
     }
 
-    private func monthNavigationSubtitle(defaultsToToday: Bool) -> String {
-        if let civilDateRangeTitle {
-            let selectionText = defaultsToToday ? "今天优先选中" : "默认选中初一"
-            return "\(civilDateRangeTitle) · \(selectionText)"
-        }
-
-        return LunarCalendarFormatting.monthSubtitle(
+    private var monthNavigationSubtitle: String {
+        let fallback = LunarCalendarFormatting.monthSubtitle(
             dayCount: month.dayCount,
             stemIndex: month.monthStemIndex,
             branchIndex: month.monthBranchIndex
+        )
+        return Self.monthNavigationSubtitle(
+            civilDateRangeTitle: civilDateRangeTitle,
+            fallback: fallback
         )
     }
 
@@ -229,10 +228,10 @@ struct LunarMonthGrid: View {
             }
         }
 
-        let todayDayIndex = todayDayIndex.flatMap { todayDayIndex in
-            days.contains(where: { $0.dayIndex == todayDayIndex }) ? todayDayIndex : nil
-        }
-        daySelection.dayIndex = todayDayIndex ?? days.first?.dayIndex
+        daySelection.dayIndex = Self.defaultDayIndex(
+            in: days.map(\.dayIndex),
+            todayDayIndex: todayDayIndex
+        )
     }
 
     private func finishPendingMonthSwitch() {
@@ -252,5 +251,20 @@ struct LunarMonthGrid: View {
     private func fullCivilDateTitle(for civilDate: CivilDate) -> String {
         let prefix = civilDate.calendarStyle == .julian ? "儒略" : "公历"
         return "\(prefix) \(civilDate.year)年\(civilDate.month)月\(civilDate.dayOfMonth)日"
+    }
+
+    static func monthNavigationSubtitle(
+        civilDateRangeTitle: String?,
+        fallback: String
+    ) -> String {
+        civilDateRangeTitle ?? fallback
+    }
+
+    static func defaultDayIndex(in dayIndices: [Int], todayDayIndex: Int?) -> Int? {
+        if let todayDayIndex, dayIndices.contains(todayDayIndex) {
+            return todayDayIndex
+        }
+
+        return dayIndices.first
     }
 }

--- a/Sources/ChineseCalendarUI/Tests/LunarMonthGridTests.swift
+++ b/Sources/ChineseCalendarUI/Tests/LunarMonthGridTests.swift
@@ -1,0 +1,51 @@
+@testable import ChineseCalendarUI
+import Testing
+
+@Test func monthNavigationSubtitleShowsOnlyCivilDateRangeWhenAvailable() {
+    let dateRange = "儒略 -220年1月1日 - 儒略 -220年1月27日"
+
+    let subtitle = LunarMonthGrid.monthNavigationSubtitle(
+        civilDateRangeTitle: dateRange,
+        fallback: "27天 · 丙寅月"
+    )
+
+    #expect(subtitle == dateRange)
+    #expect(!subtitle.contains("今天优先选中"))
+    #expect(!subtitle.contains("默认选中初一"))
+}
+
+@Test func monthNavigationSubtitleUsesMonthSummaryWithoutCivilDates() {
+    let subtitle = LunarMonthGrid.monthNavigationSubtitle(
+        civilDateRangeTitle: nil,
+        fallback: "27天 · 丙寅月"
+    )
+
+    #expect(subtitle == "27天 · 丙寅月")
+}
+
+@Test func defaultDaySelectionPrefersTodayWhenItBelongsToTheMonth() {
+    let selectedDayIndex = LunarMonthGrid.defaultDayIndex(
+        in: [101, 102, 103],
+        todayDayIndex: 102
+    )
+
+    #expect(selectedDayIndex == 102)
+}
+
+@Test func defaultDaySelectionUsesFirstDayWhenTodayIsOutsideTheMonth() {
+    let selectedDayIndex = LunarMonthGrid.defaultDayIndex(
+        in: [101, 102, 103],
+        todayDayIndex: 999
+    )
+
+    #expect(selectedDayIndex == 101)
+}
+
+@Test func defaultDaySelectionIsNilForAnEmptyMonth() {
+    let selectedDayIndex = LunarMonthGrid.defaultDayIndex(
+        in: [],
+        todayDayIndex: 102
+    )
+
+    #expect(selectedDayIndex == nil)
+}


### PR DESCRIPTION
## Summary

- 月份副标题只展示公历或儒略历日期范围
- 保留当前月优先选择今天、其他月份选择初一的行为
- 增加副标题格式和默认日期选择的单元测试

## Verification

- SwiftFormat：通过
- SwiftLint：通过，0 violations
- Swift package tests：69 passed
- iOS Simulator tests：58 passed，0 failed，0 skipped
- ChineseCalendar-iOS Simulator build：通过
- Simulator UI：当前月份仍选中今天；不含今天的月份仍选中初一；副标题均只显示日期范围

Closes #85