### PR TITLE
UI 年份使用公元前/公元纪年展示

### DIFF
--- a/Sources/ChineseCalendarCore/LunarCalendarFormatting.swift
+++ b/Sources/ChineseCalendarCore/LunarCalendarFormatting.swift
@@ -20,7 +20,11 @@ public enum LunarMonthSize: Int, Codable, CaseIterable, Sendable {
 
 public enum LunarCalendarFormatting {
     public static func yearTitle(lunarYearNumber: Int) -> String {
-        "农历 \(lunarYearNumber) 年"
+        if lunarYearNumber > 0 {
+            "公元 \(lunarYearNumber) 年"
+        } else {
+            "公元前 \(1 - lunarYearNumber) 年"
+        }
     }
 
     public static func yearSubtitle(stemIndex: Int, branchIndex: Int) -> String {

--- a/Sources/ChineseCalendarCore/LunarCalendarFormatting.swift
+++ b/Sources/ChineseCalendarCore/LunarCalendarFormatting.swift
@@ -23,7 +23,7 @@ public enum LunarCalendarFormatting {
         if lunarYearNumber > 0 {
             "公元 \(lunarYearNumber) 年"
         } else {
-            "公元前 \(1 - lunarYearNumber) 年"
+            "公元前 \(lunarYearNumber.magnitude + 1) 年"
         }
     }
 

--- a/Sources/ChineseCalendarCore/Tests/LunarCalendarFormattingTests.swift
+++ b/Sources/ChineseCalendarCore/Tests/LunarCalendarFormattingTests.swift
@@ -1,6 +1,20 @@
 @testable import ChineseCalendarCore
 import Testing
 
+@Test(
+    "年份标题将天文学纪年转换为没有公元 0 年的历史纪年",
+    arguments: [
+        (-220, "公元前 221 年"),
+        (-1, "公元前 2 年"),
+        (0, "公元前 1 年"),
+        (1, "公元 1 年"),
+        (2026, "公元 2026 年"),
+    ]
+)
+func yearTitleUsesHistoricalEra(lunarYearNumber: Int, expectedTitle: String) {
+    #expect(LunarCalendarFormatting.yearTitle(lunarYearNumber: lunarYearNumber) == expectedTitle)
+}
+
 @Test func monthTitleIncludesLunarMonthSizeWhenKnown() {
     #expect(LunarCalendarFormatting.monthTitle(monthNumberInYear: 8, isLeapMonth: true, dayCount: 30) == "闰八月大")
     #expect(LunarCalendarFormatting.monthTitle(monthNumberInYear: 8, isLeapMonth: false, dayCount: 29) == "八月小")

--- a/Sources/ChineseCalendarCore/Tests/LunarCalendarFormattingTests.swift
+++ b/Sources/ChineseCalendarCore/Tests/LunarCalendarFormattingTests.swift
@@ -8,7 +8,7 @@ import Testing
         (-1, "公元前 2 年"),
         (0, "公元前 1 年"),
         (1, "公元 1 年"),
-        (2026, "公元 2026 年"),
+        (2026, "公元 2026 年")
     ]
 )
 func yearTitleUsesHistoricalEra(lunarYearNumber: Int, expectedTitle: String) {


### PR DESCRIPTION
## 概要
- 在 Core 的统一年份格式化入口中，将天文学纪年转换为没有公元 0 年的公元前/公元纪年
- 保持持久化、排序、路由和日期计算继续使用原始 lunarYearNumber
- 补充公元前、公元分界与现代年份的参数化单元测试

## 验证
- swift test --package-path Sources（70 tests passed）
- XcodeBuildMCP：ChineseCalendar-iOS 在 chinesedate iPhone 17 Pro Max 构建、安装并运行成功
- Simulator UI snapshot：年份选择器显示并朗读“公元 2026 年, 丙午年”

Closes #84