### PR TITLE
年份选择器按世纪分组并提供原生章节索引

### DIFF
--- a/Sources/ChineseCalendarUI/Calendar/Years/CalendarYearPickerView.swift
+++ b/Sources/ChineseCalendarUI/Calendar/Years/CalendarYearPickerView.swift
@@ -4,41 +4,56 @@ import SwiftUI
 
 /// 显示可选农历年列表，由所在 NavigationStack 提供导航容器。
 struct CalendarYearPickerView: View {
-    let years: [ChineseLunarYear]
     let selectedYearNumber: Int?
     let selectYear: (Int) -> Void
 
+    private let yearSections: [CalendarYearSection]
+    private let availableYearNumbers: [Int]
     @State private var hasResolvedInitialScrollTarget = false
+
+    init(
+        years: [ChineseLunarYear],
+        selectedYearNumber: Int?,
+        selectYear: @escaping (Int) -> Void
+    ) {
+        self.selectedYearNumber = selectedYearNumber
+        self.selectYear = selectYear
+        yearSections = CalendarYearSection.sections(for: years)
+        availableYearNumbers = years.map(\.lunarYearNumber)
+    }
 
     var body: some View {
         ScrollViewReader { proxy in
             List {
-                Section("农历年") {
-                    ForEach(years, id: \.lunarYearNumber) { year in
-                        Button {
-                            selectYear(year.lunarYearNumber)
-                        } label: {
-                            HStack(spacing: 12) {
-                                LunarYearRow(year: year)
+                ForEach(yearSections) { section in
+                    Section(section.title) {
+                        ForEach(section.years, id: \.lunarYearNumber) { year in
+                            Button {
+                                selectYear(year.lunarYearNumber)
+                            } label: {
+                                HStack(spacing: 12) {
+                                    LunarYearRow(year: year)
 
-                                Spacer()
+                                    Spacer()
 
-                                if year.lunarYearNumber == selectedYearNumber {
-                                    Image(systemSymbol: .checkmark)
-                                        .font(.headline)
-                                        .foregroundStyle(.tint)
-                                        .accessibilityHidden(true)
+                                    if year.lunarYearNumber == selectedYearNumber {
+                                        Image(systemSymbol: .checkmark)
+                                            .font(.headline)
+                                            .foregroundStyle(.tint)
+                                            .accessibilityHidden(true)
+                                    }
                                 }
+                                .contentShape(Rectangle())
                             }
-                            .contentShape(Rectangle())
+                            .buttonStyle(.plain)
+                            .id(year.lunarYearNumber)
+                            .accessibilityAddTraits(year.lunarYearNumber == selectedYearNumber ? .isSelected : [])
                         }
-                        .buttonStyle(.plain)
-                        .id(year.lunarYearNumber)
-                        .accessibilityAddTraits(year.lunarYearNumber == selectedYearNumber ? .isSelected : [])
                     }
+                    .sectionIndexLabel(section.indexTitle)
                 }
             }
-            .onChange(of: years.map(\.lunarYearNumber), initial: true) {
+            .onChange(of: availableYearNumbers, initial: true) {
                 positionInitiallyIfNeeded(using: proxy)
             }
         }
@@ -68,7 +83,6 @@ struct CalendarYearPickerView: View {
             return
         }
 
-        let availableYearNumbers = years.map(\.lunarYearNumber)
         guard !availableYearNumbers.isEmpty else {
             return
         }

--- a/Sources/ChineseCalendarUI/Calendar/Years/CalendarYearSection.swift
+++ b/Sources/ChineseCalendarUI/Calendar/Years/CalendarYearSection.swift
@@ -1,0 +1,41 @@
+import ChineseCalendarPersistence
+
+struct CalendarYearSection: Identifiable {
+    /// 公元世纪为正数，公元前世纪为负数；不存在 0 世纪。
+    let id: Int
+    let years: [ChineseLunarYear]
+
+    var title: String {
+        if id < 0 {
+            "公元前 \(-id) 世纪"
+        } else {
+            "公元 \(id) 世纪"
+        }
+    }
+
+    var indexTitle: String {
+        if id < 0 {
+            "前\(-id)"
+        } else {
+            "\(id)"
+        }
+    }
+
+    static func sections(for years: [ChineseLunarYear]) -> [Self] {
+        Dictionary(grouping: years) { year in
+            signedCentury(lunarYearNumber: year.lunarYearNumber)
+        }
+        .map { century, years in
+            Self(id: century, years: years)
+        }
+        .sorted { $0.id < $1.id }
+    }
+
+    static func signedCentury(lunarYearNumber: Int) -> Int {
+        if lunarYearNumber > 0 {
+            (lunarYearNumber - 1) / 100 + 1
+        } else {
+            -(1 - lunarYearNumber / 100)
+        }
+    }
+}

--- a/Sources/ChineseCalendarUI/Tests/CalendarYearPickerViewTests.swift
+++ b/Sources/ChineseCalendarUI/Tests/CalendarYearPickerViewTests.swift
@@ -1,5 +1,45 @@
+import ChineseCalendarPersistence
 @testable import ChineseCalendarUI
 import Testing
+
+@Test(
+    "天文学纪年映射到没有 0 世纪的公元前与公元世纪",
+    arguments: [
+        (-220, -3),
+        (-199, -2),
+        (-100, -2),
+        (-99, -1),
+        (0, -1),
+        (1, 1),
+        (100, 1),
+        (101, 2),
+        (2026, 21)
+    ]
+)
+func yearPickerMapsYearsToSignedCenturies(lunarYearNumber: Int, expectedCentury: Int) {
+    #expect(CalendarYearSection.signedCentury(lunarYearNumber: lunarYearNumber) == expectedCentury)
+}
+
+@Test func yearPickerGroupsYearsIntoChronologicalIndexedSections() {
+    let yearNumbers = [-220, -199, 0, 1, 100, 101, 2026]
+    let years = yearNumbers.map {
+        ChineseLunarYear(lunarYearNumber: $0, yearStemIndex: 0, yearBranchIndex: 0)
+    }
+
+    let sections = CalendarYearSection.sections(for: years)
+
+    #expect(sections.map(\.id) == [-3, -2, -1, 1, 2, 21])
+    #expect(sections.map(\.title) == [
+        "公元前 3 世纪",
+        "公元前 2 世纪",
+        "公元前 1 世纪",
+        "公元 1 世纪",
+        "公元 2 世纪",
+        "公元 21 世纪"
+    ])
+    #expect(sections.map(\.indexTitle) == ["前3", "前2", "前1", "1", "2", "21"])
+    #expect(sections.flatMap(\.years).map(\.lunarYearNumber) == yearNumbers)
+}
 
 @Test func yearPickerInitialScrollTargetFindsSelectedYear() {
     let target = CalendarYearPickerView.initialScrollTarget(


### PR DESCRIPTION
## 概要
- 将年份选择器按公元前/公元世纪分组，并按历史时间顺序展示 Section
- 使用 SwiftUI sectionIndexLabel 提供 iOS 26 原生右侧章节索引
- 保持行 ID、选中回调和初始滚动继续使用 lunarYearNumber
- 补充世纪边界、分组顺序、标题和索引标签测试

## 验证
- swift test --package-path Sources（71 tests passed）
- ./Scripts/format.sh --check（passed）
- ./Scripts/lint.sh（0 violations）
- XcodeBuildMCP：ChineseCalendar-iOS 在 chinesedate iPhone 17 Pro Max 构建、安装并运行成功
- Simulator 实测：选中 2026 年仍居中显示；世纪章节和右侧“前3…22”原生索引可见

Closes #87