### PR TITLE
拆分 CalendarDestinationView 的目标分发与空状态职责

### DIFF
--- a/Sources/ChineseCalendarUI/Home/CalendarHomeCoordinator.swift
+++ b/Sources/ChineseCalendarUI/Home/CalendarHomeCoordinator.swift
@@ -1,6 +1,6 @@
 import Observation
 
-/// 协调日历主页的初始目的地与 deep link；具体页面状态由页面自己保存。
+/// 协调日历主页的 deep link；具体页面状态由页面自己保存。
 @MainActor
 @Observable
 final class CalendarHomeCoordinator {
@@ -8,33 +8,6 @@ final class CalendarHomeCoordinator {
 
     init(router: CalendarRouter = CalendarRouter()) {
         self.router = router
-    }
-
-    func selectDefaultYearIfNeeded(availableYearNumbers yearNumbers: [Int], preferredYearNumber: Int) -> Int? {
-        guard !yearNumbers.isEmpty else {
-            return nil
-        }
-
-        let currentYearNumber = router.yearsRootDestination?.lunarYearNumber
-        if let currentYearNumber, yearNumbers.contains(currentYearNumber) {
-            return nil
-        }
-
-        if router.yearsRootDestination != nil, currentYearNumber == nil {
-            return nil
-        }
-
-        let defaultYearNumber = yearNumbers.first { $0 == preferredYearNumber } ?? yearNumbers.last
-        guard let defaultYearNumber else {
-            return nil
-        }
-
-        let shouldSelectYearsTab = router.selectedDestination == nil
-        router.setYearsRootDestination(.lunarYear(defaultYearNumber))
-        if shouldSelectYearsTab {
-            router.selectedTab = .years
-        }
-        return defaultYearNumber
     }
 
     func openDeepLink(_ deepLink: CalendarDeepLink) {

--- a/Sources/ChineseCalendarUI/Home/CalendarHomeView.swift
+++ b/Sources/ChineseCalendarUI/Home/CalendarHomeView.swift
@@ -1,5 +1,4 @@
 import ChineseCalendarCore
-import ChineseCalendarLogging
 import ChineseCalendarPersistence
 import Foundation
 import NavigationCore
@@ -32,7 +31,6 @@ public struct CalendarHomeView<BottomStatusBar: View>: View {
             #if os(iOS)
                 CalendarHomeTabView(
                     coordinator: coordinator,
-                    emptyStateDescription: emptyStateDescription,
                     settingsCoordinator: settingsCoordinator,
                     bottomStatusBarIsPresented: bottomStatusBarIsPresented,
                     bottomStatusBar: bottomStatusBar
@@ -40,8 +38,7 @@ public struct CalendarHomeView<BottomStatusBar: View>: View {
             #else
                 CalendarHomeSplitView(
                     coordinator: coordinator,
-                    years: years,
-                    emptyStateDescription: emptyStateDescription
+                    years: years
                 )
             #endif
         }
@@ -57,36 +54,9 @@ public struct CalendarHomeView<BottomStatusBar: View>: View {
         }
         .task {
             openColdLaunchDeepLinkIfNeeded()
-            selectDefaultYearIfNeeded()
-        }
-        .onChange(of: years.map(\.lunarYearNumber)) {
-            selectDefaultYearIfNeeded()
         }
         .onOpenURL { url in
             open(url)
-        }
-    }
-
-    private var emptyStateDescription: String {
-        if years.isEmpty {
-            return "正在加载 SwiftData 日历数据。"
-        }
-
-        return "请选择一个农历年。"
-    }
-
-    private func selectDefaultYearIfNeeded() {
-        let yearNumbers = years.map(\.lunarYearNumber)
-        guard !yearNumbers.isEmpty else {
-            ChineseCalendarLog.ui.debug("CalendarHomeView is waiting for SwiftData years")
-            return
-        }
-
-        if let selectedYearNumber = coordinator.selectDefaultYearIfNeeded(
-            availableYearNumbers: yearNumbers,
-            preferredYearNumber: ChineseLunarCalendar.yearNumber()
-        ) {
-            ChineseCalendarLog.ui.info("Selected default lunar year \(selectedYearNumber)")
         }
     }
 

--- a/Sources/ChineseCalendarUI/Home/Navigation/CalendarDestinationModifiers.swift
+++ b/Sources/ChineseCalendarUI/Home/Navigation/CalendarDestinationModifiers.swift
@@ -1,12 +1,9 @@
 import SwiftUI
 
 extension View {
-    func calendarDestinations(emptyStateDescription: String) -> some View {
+    func calendarDestinations() -> some View {
         navigationDestination(for: CalendarDestination.self) { destination in
-            CalendarDestinationView(
-                destination: destination,
-                emptyStateDescription: emptyStateDescription
-            )
+            CalendarDestinationView(destination: destination)
         }
     }
 }

--- a/Sources/ChineseCalendarUI/Home/Navigation/CalendarDestinationView.swift
+++ b/Sources/ChineseCalendarUI/Home/Navigation/CalendarDestinationView.swift
@@ -3,8 +3,7 @@ import SwiftUI
 
 /// 供导航容器使用，将 CalendarDestination 分发到对应页面。
 struct CalendarDestinationView: View {
-    let destination: CalendarDestination?
-    let emptyStateDescription: String
+    let destination: CalendarDestination
 
     var body: some View {
         Group {
@@ -22,7 +21,23 @@ struct CalendarDestinationView: View {
                 EmperorDetailView(emperorID: emperorID)
             case let .yearPicker(yearPicker):
                 CalendarYearPickerDestinationView(destination: yearPicker)
-            case nil:
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(.calendarSystemBackground)
+    }
+}
+
+/// 承载允许尚未选择 CalendarDestination 的根页面，并在未选择时显示空状态。
+struct CalendarDestinationRootView: View {
+    let destination: CalendarDestination?
+    let emptyStateDescription: String
+
+    var body: some View {
+        Group {
+            if let destination {
+                CalendarDestinationView(destination: destination)
+            } else {
                 ContentUnavailableView {
                     Label("Chinese Calendar", systemSymbol: .calendar)
                 } description: {

--- a/Sources/ChineseCalendarUI/Home/Navigation/CalendarDestinationView.swift
+++ b/Sources/ChineseCalendarUI/Home/Navigation/CalendarDestinationView.swift
@@ -1,4 +1,3 @@
-import SFSafeSymbols
 import SwiftUI
 
 /// 供导航容器使用，将 CalendarDestination 分发到对应页面。
@@ -21,28 +20,6 @@ struct CalendarDestinationView: View {
                 EmperorDetailView(emperorID: emperorID)
             case let .yearPicker(yearPicker):
                 CalendarYearPickerDestinationView(destination: yearPicker)
-            }
-        }
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .background(.calendarSystemBackground)
-    }
-}
-
-/// 承载允许尚未选择 CalendarDestination 的根页面，并在未选择时显示空状态。
-struct CalendarDestinationRootView: View {
-    let destination: CalendarDestination?
-    let emptyStateDescription: String
-
-    var body: some View {
-        Group {
-            if let destination {
-                CalendarDestinationView(destination: destination)
-            } else {
-                ContentUnavailableView {
-                    Label("Chinese Calendar", systemSymbol: .calendar)
-                } description: {
-                    Text(emptyStateDescription)
-                }
             }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)

--- a/Sources/ChineseCalendarUI/Home/Navigation/CalendarPresentationNodeView.swift
+++ b/Sources/ChineseCalendarUI/Home/Navigation/CalendarPresentationNodeView.swift
@@ -7,15 +7,12 @@ struct CalendarPresentationNodeView: View {
 
     var body: some View {
         NavigationCore.NavigationPresentationNodeView(node: node) { destination, dismiss in
-            CalendarDestinationView(
-                destination: destination,
-                emptyStateDescription: "请选择一个农历年。"
-            )
-            .toolbar {
-                ToolbarItem(placement: .cancellationAction) {
-                    Button("关闭", action: dismiss)
+            CalendarDestinationView(destination: destination)
+                .toolbar {
+                    ToolbarItem(placement: .cancellationAction) {
+                        Button("关闭", action: dismiss)
+                    }
                 }
-            }
         }
     }
 }

--- a/Sources/ChineseCalendarUI/Home/Navigation/CalendarRouter.swift
+++ b/Sources/ChineseCalendarUI/Home/Navigation/CalendarRouter.swift
@@ -11,10 +11,6 @@ final class CalendarRouter {
         set { navigation.selectedScope = newValue }
     }
 
-    var yearsRootDestination: CalendarDestination? {
-        navigation.rootDestination(for: .years)
-    }
-
     var yearsPath: [CalendarDestination] {
         get { navigation.path(for: .years) }
         set { navigation.setPath(newValue, for: .years) }
@@ -45,21 +41,13 @@ final class CalendarRouter {
 
     init(
         selectedTab: CalendarTab = .years,
-        yearsRootDestination: CalendarDestination? = nil,
         yearsPath: [CalendarDestination] = [],
         historyPath: [CalendarDestination] = []
     ) {
-        var roots: [CalendarTab: CalendarDestination] = [:]
-        roots[.years] = yearsRootDestination
         navigation = NavigationRouter(
             selectedScope: selectedTab,
-            rootDestinations: roots,
             paths: [.years: yearsPath, .history: historyPath]
         )
-    }
-
-    func setYearsRootDestination(_ destination: CalendarDestination?) {
-        navigation.setRootDestination(destination, for: .years)
     }
 
     func path(for tab: CalendarTab) -> [CalendarDestination] {
@@ -122,7 +110,7 @@ final class CalendarRouter {
     ) -> NavigationRequest<CalendarTab, CalendarDestination> {
         switch deepLink {
         case let .lunarYear(yearNumber, monthIndex):
-            .setRoot(.lunarYear(yearNumber, monthIndex: monthIndex), on: .years)
+            .replacePath([.lunarYear(yearNumber, monthIndex: monthIndex)], on: .years)
         case let .dynasty(dynastyID):
             .replacePath([.dynasty(dynastyID)], on: .history)
         case let .emperor(emperorID):

--- a/Sources/ChineseCalendarUI/Home/Platform/CalendarHomeSplitView.swift
+++ b/Sources/ChineseCalendarUI/Home/Platform/CalendarHomeSplitView.swift
@@ -23,11 +23,11 @@ struct CalendarHomeSplitView: View {
             .navigationTitle("年份")
         } detail: {
             NavigationStack(path: $router.yearsPath) {
-                CalendarDestinationView(
+                CalendarDestinationRootView(
                     destination: router.yearsRootDestination,
                     emptyStateDescription: emptyStateDescription
                 )
-                .calendarDestinations(emptyStateDescription: emptyStateDescription)
+                .calendarDestinations()
             }
         }
     }

--- a/Sources/ChineseCalendarUI/Home/Platform/CalendarHomeSplitView.swift
+++ b/Sources/ChineseCalendarUI/Home/Platform/CalendarHomeSplitView.swift
@@ -6,7 +6,6 @@ import SwiftUI
 struct CalendarHomeSplitView: View {
     @Bindable var coordinator: CalendarHomeCoordinator
     let years: [ChineseLunarYear]
-    let emptyStateDescription: String
 
     var body: some View {
         @Bindable var router = coordinator.router
@@ -23,27 +22,27 @@ struct CalendarHomeSplitView: View {
             .navigationTitle("年份")
         } detail: {
             NavigationStack(path: $router.yearsPath) {
-                CalendarDestinationRootView(
-                    destination: router.yearsRootDestination,
-                    emptyStateDescription: emptyStateDescription
-                )
-                .calendarDestinations()
+                LunarYearDetailView(initialYearNumber: ChineseLunarCalendar.yearNumber())
+                    .calendarDestinations()
             }
         }
     }
 
     private var selection: Binding<CalendarDestination?> {
         Binding {
-            coordinator.router.yearsRootDestination?.lunarYearNumber.map {
-                .lunarYear($0)
-            }
+            coordinator.router.currentDestination(on: .years)
+                ?? .lunarYear(ChineseLunarCalendar.yearNumber())
         } set: { destination in
-            guard case .lunarYear? = destination else {
-                coordinator.router.setYearsRootDestination(nil)
+            guard case let .lunarYear(yearNumber, _, _)? = destination else {
+                coordinator.router.setPath([], for: .years)
                 return
             }
 
-            coordinator.router.setYearsRootDestination(destination)
+            if yearNumber == ChineseLunarCalendar.yearNumber() {
+                coordinator.router.setPath([], for: .years)
+            } else {
+                coordinator.router.setPath([.lunarYear(yearNumber)], for: .years)
+            }
         }
     }
 }

--- a/Sources/ChineseCalendarUI/Home/Platform/CalendarHomeTabView.swift
+++ b/Sources/ChineseCalendarUI/Home/Platform/CalendarHomeTabView.swift
@@ -16,8 +16,11 @@ import SwiftUI
 
             TabView(selection: $router.selectedTab) {
                 NavigationStack(path: $router.yearsPath) {
-                    calendarDestination(for: router.yearsRootDestination)
-                        .calendarDestinations(emptyStateDescription: emptyStateDescription)
+                    CalendarDestinationRootView(
+                        destination: router.yearsRootDestination,
+                        emptyStateDescription: emptyStateDescription
+                    )
+                    .calendarDestinations()
                 }
                 .tabItem {
                     Label(CalendarTab.years.title, systemSymbol: CalendarTab.years.systemSymbol)
@@ -26,7 +29,7 @@ import SwiftUI
 
                 NavigationStack(path: $router.historyPath) {
                     CalendarHistoryHomeView()
-                        .calendarDestinations(emptyStateDescription: emptyStateDescription)
+                        .calendarDestinations()
                 }
                 .tabItem {
                     Label(CalendarTab.history.title, systemSymbol: CalendarTab.history.systemSymbol)
@@ -51,13 +54,6 @@ import SwiftUI
             }
             .calendarTabViewBottomAccessory(isEnabled: bottomStatusBarIsPresented, content: bottomStatusBar)
             .background(.calendarSystemBackground)
-        }
-
-        private func calendarDestination(for destination: CalendarDestination?) -> some View {
-            CalendarDestinationView(
-                destination: destination,
-                emptyStateDescription: emptyStateDescription
-            )
         }
     }
 #endif

--- a/Sources/ChineseCalendarUI/Home/Platform/CalendarHomeTabView.swift
+++ b/Sources/ChineseCalendarUI/Home/Platform/CalendarHomeTabView.swift
@@ -1,3 +1,4 @@
+import ChineseCalendarCore
 import ChineseCalendarPersistence
 import SFSafeSymbols
 import SwiftUI
@@ -6,7 +7,6 @@ import SwiftUI
     /// 供 iOS 的 CalendarHomeView 使用，以标签页组织日历、历史和设置界面。
     struct CalendarHomeTabView<BottomStatusBar: View>: View {
         @Bindable var coordinator: CalendarHomeCoordinator
-        let emptyStateDescription: String
         let settingsCoordinator: ChineseCalendarStoreCoordinator?
         let bottomStatusBarIsPresented: Bool
         let bottomStatusBar: () -> BottomStatusBar
@@ -16,11 +16,8 @@ import SwiftUI
 
             TabView(selection: $router.selectedTab) {
                 NavigationStack(path: $router.yearsPath) {
-                    CalendarDestinationRootView(
-                        destination: router.yearsRootDestination,
-                        emptyStateDescription: emptyStateDescription
-                    )
-                    .calendarDestinations()
+                    LunarYearDetailView(initialYearNumber: ChineseLunarCalendar.yearNumber())
+                        .calendarDestinations()
                 }
                 .tabItem {
                     Label(CalendarTab.years.title, systemSymbol: CalendarTab.years.systemSymbol)

--- a/Sources/ChineseCalendarUI/Tests/CalendarRouterTests.swift
+++ b/Sources/ChineseCalendarUI/Tests/CalendarRouterTests.swift
@@ -3,35 +3,6 @@ import Foundation
 import Testing
 
 @MainActor
-@Test func defaultSelectionPrefersCurrentLunarYearWhenAvailable() {
-    let coordinator = CalendarHomeCoordinator()
-
-    let selectedYear = coordinator.selectDefaultYearIfNeeded(
-        availableYearNumbers: [2024, 2025, 2026],
-        preferredYearNumber: 2025
-    )
-
-    #expect(selectedYear == 2025)
-    #expect(coordinator.router.selectedDestination == .lunarYear(2025))
-    #expect(coordinator.router.yearsRootDestination == .lunarYear(2025))
-    #expect(coordinator.router.yearsPath.isEmpty)
-}
-
-@MainActor
-@Test func defaultSelectionKeepsExistingValidRoute() {
-    let router = CalendarRouter(yearsRootDestination: .lunarYear(2024))
-    let coordinator = CalendarHomeCoordinator(router: router)
-
-    let selectedYear = coordinator.selectDefaultYearIfNeeded(
-        availableYearNumbers: [2024, 2025, 2026],
-        preferredYearNumber: 2025
-    )
-
-    #expect(selectedYear == nil)
-    #expect(router.selectedDestination == .lunarYear(2024))
-}
-
-@MainActor
 @Test func pushUpdatesSelectedTabPath() {
     let router = CalendarRouter()
 
@@ -46,11 +17,9 @@ import Testing
 @Test func tabPathsDoNotPolluteEachOther() {
     let router = CalendarRouter()
 
-    router.setYearsRootDestination(.lunarYear(2024))
     router.push(.lunarYear(2025), on: .years)
     router.push(.dynasty("qin"), on: .history)
 
-    #expect(router.yearsRootDestination == .lunarYear(2024))
     #expect(router.yearsPath == [.lunarYear(2025)])
     #expect(router.historyPath == [.dynasty("qin")])
     #expect(router.selectedDestination == .dynasty("qin"))
@@ -58,16 +27,12 @@ import Testing
 }
 
 @MainActor
-@Test func changingYearsRootClearsItsPushPath() {
-    let router = CalendarRouter(
-        yearsRootDestination: .lunarYear(2024),
-        yearsPath: [.lunarYear(2025)]
-    )
+@Test func replacingYearsPathChangesItsCurrentDestination() {
+    let router = CalendarRouter(yearsPath: [.lunarYear(2025)])
 
-    router.setYearsRootDestination(.lunarYear(2026))
+    router.setPath([.lunarYear(2026)], for: .years)
 
-    #expect(router.yearsRootDestination == .lunarYear(2026))
-    #expect(router.yearsPath.isEmpty)
+    #expect(router.yearsPath == [.lunarYear(2026)])
     #expect(router.currentDestination(on: .years) == .lunarYear(2026))
 }
 
@@ -88,7 +53,7 @@ import Testing
 
 @MainActor
 @Test func browseStateCanMoveAcrossYearsWithoutChangingRouter() {
-    let router = CalendarRouter(yearsRootDestination: .lunarYear(2024))
+    let router = CalendarRouter()
     let browseState = LunarCalendarBrowseState(
         displayedYearNumber: 2024,
         selectedDayIndex: 2_400_101
@@ -96,7 +61,7 @@ import Testing
 
     browseState.select(yearNumber: 2025, monthIndex: 25006)
 
-    #expect(router.currentDestination(on: .years) == .lunarYear(2024))
+    #expect(router.currentDestination(on: .years) == nil)
     #expect(browseState.displayedYearNumber == 2025)
     #expect(browseState.selectedMonthIndex == 25006)
     #expect(browseState.daySelection.dayIndex == nil)
@@ -171,7 +136,7 @@ import Testing
 
 @MainActor
 @Test func hotDeepLinkDismissesActivePresentationTreeBeforeRouting() {
-    let router = CalendarRouter(yearsRootDestination: .lunarYear(2024))
+    let router = CalendarRouter(yearsPath: [.lunarYear(2024)])
     let coordinator = CalendarHomeCoordinator(router: router)
     router.presentSheet(.lunarYear(2025))
 
@@ -180,7 +145,7 @@ import Testing
     #expect(router.sheet == nil)
     #expect(
         router.navigation.deferredRequest
-            == .setRoot(.lunarYear(2026, monthIndex: 26001), on: .years)
+            == .replacePath([.lunarYear(2026, monthIndex: 26001)], on: .years)
     )
     #expect(router.currentDestination(on: .years) == .lunarYear(2024))
 
@@ -188,8 +153,7 @@ import Testing
 
     #expect(router.navigation.deferredRequest == nil)
     #expect(router.currentDestination(on: .years) == .lunarYear(2026, monthIndex: 26001))
-    #expect(router.yearsRootDestination == .lunarYear(2026, monthIndex: 26001))
-    #expect(router.yearsPath.isEmpty)
+    #expect(router.yearsPath == [.lunarYear(2026, monthIndex: 26001)])
 }
 
 @MainActor
@@ -199,8 +163,7 @@ import Testing
     coordinator.openColdLaunchDeepLink(.lunarYear(2026, monthIndex: 26001))
 
     #expect(coordinator.router.navigation.deferredRequest == nil)
-    #expect(coordinator.router.yearsRootDestination == .lunarYear(2026, monthIndex: 26001))
-    #expect(coordinator.router.yearsPath.isEmpty)
+    #expect(coordinator.router.yearsPath == [.lunarYear(2026, monthIndex: 26001)])
     #expect(
         coordinator.router.currentDestination(on: .years)
             == .lunarYear(2026, monthIndex: 26001)
@@ -215,23 +178,6 @@ import Testing
 
     #expect(coordinator.router.selectedTab == .history)
     #expect(coordinator.router.historyPath == [.dynasty("qin")])
-}
-
-@MainActor
-@Test func defaultSelectionInitializesYearsRootWithoutOverridingDynastyDeepLink() {
-    let coordinator = CalendarHomeCoordinator()
-
-    coordinator.openColdLaunchDeepLink(.dynasty("ming"))
-    let selectedYear = coordinator.selectDefaultYearIfNeeded(
-        availableYearNumbers: [2024, 2025, 2026],
-        preferredYearNumber: 2025
-    )
-
-    #expect(selectedYear == 2025)
-    #expect(coordinator.router.yearsRootDestination == .lunarYear(2025))
-    #expect(coordinator.router.yearsPath.isEmpty)
-    #expect(coordinator.router.selectedTab == .history)
-    #expect(coordinator.router.historyPath == [.dynasty("ming")])
 }
 
 @MainActor


### PR DESCRIPTION
## Summary

- make `CalendarDestinationView` dispatch a non-optional destination only
- use `LunarYearDetailView` directly as the fixed calendar root on iOS and macOS
- remove `CalendarDestinationRootView`, root empty-state plumbing, and `yearsRootDestination`
- route year deep links and split-view year selections through `yearsPath`
- keep pushed, sheet, and full-screen destinations on the shared non-optional dispatcher

## Verification

- 58 iOS tests passed with 0 failures
- iOS Simulator Build & Run passed
- verified the fixed current-year root and year-picker sheet selection in Simulator
- macOS host SwiftPM build of `ChineseCalendarUI` passed
- SwiftFormat lint and `git diff --check` passed

Fixes #91