### PR TITLE
使用 JDN 定位和刷新今天

### DIFF
--- a/Sources/ChineseCalendarCore/JulianDayNumber.swift
+++ b/Sources/ChineseCalendarCore/JulianDayNumber.swift
@@ -1,0 +1,72 @@
+import Foundation
+
+/// 儒略日数（Julian Day Number，JDN）的换算工具；不表示儒略历日期。
+public enum JulianDayNumber {
+    /// 按标准 JDN 约定，1970-01-01 的 UTC 正午对应 JDN 2,440,588。
+    private static let unixEpoch = 2_440_588
+
+    private static let unixEpochNoonUTC: Date = {
+        var components = DateComponents()
+        components.timeZone = .gmt
+        components.year = 1970
+        components.month = 1
+        components.day = 1
+        components.hour = 12
+
+        guard let date = gregorianUTCCalendar.date(from: components) else {
+            preconditionFailure("无法构造 Unix epoch 的 UTC 正午日期")
+        }
+        return date
+    }()
+
+    /// 返回指定瞬间在用户时区所处 Gregorian 民用日期对应的 JDN。
+    ///
+    /// 这里先读取本地年、月、日，再把这组纯日期组件锚定到 UTC 正午，避免在本地午夜附近
+    /// 直接按 UTC 时间戳取整而得到前一天或后一天。
+    public static func forLocalGregorianDate(
+        containing date: Date,
+        timeZone: TimeZone = .autoupdatingCurrent
+    ) -> Int {
+        var localCalendar = Calendar(identifier: .gregorian)
+        localCalendar.timeZone = timeZone
+        let localComponents = localCalendar.dateComponents([.year, .month, .day], from: date)
+
+        var utcComponents = DateComponents()
+        utcComponents.timeZone = .gmt
+        utcComponents.year = localComponents.year
+        utcComponents.month = localComponents.month
+        utcComponents.day = localComponents.day
+        utcComponents.hour = 12
+
+        guard let localDateAtNoonUTC = gregorianUTCCalendar.date(from: utcComponents),
+              let dayOffset = gregorianUTCCalendar.dateComponents(
+                  [.day],
+                  from: unixEpochNoonUTC,
+                  to: localDateAtNoonUTC
+              ).day
+        else {
+            preconditionFailure("无法将用户本地 Gregorian 日期转换为 JDN")
+        }
+
+        return unixEpoch + dayOffset
+    }
+
+    /// 将整数 JDN 转为其对应的 UTC 正午。
+    public static func dateAtNoonUTC(for julianDayNumber: Int) -> Date {
+        let daysSinceUnixEpoch = julianDayNumber - unixEpoch
+        guard let date = gregorianUTCCalendar.date(
+            byAdding: .day,
+            value: daysSinceUnixEpoch,
+            to: unixEpochNoonUTC
+        ) else {
+            preconditionFailure("无法将 JDN \(julianDayNumber) 转换为 Foundation Date")
+        }
+        return date
+    }
+
+    private static var gregorianUTCCalendar: Calendar {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = .gmt
+        return calendar
+    }
+}

--- a/Sources/ChineseCalendarCore/LunarCalendarFormatting.swift
+++ b/Sources/ChineseCalendarCore/LunarCalendarFormatting.swift
@@ -19,24 +19,6 @@ public enum LunarMonthSize: Int, Codable, CaseIterable, Sendable {
 }
 
 public enum LunarCalendarFormatting {
-    /// 按标准 JDN 约定，1970-01-01 的 UTC 正午对应 JDN 2,440,588。
-    private static let unixEpochJulianDayNumber = 2_440_588
-
-    /// 用 Gregorian Calendar 构造按日偏移的 UTC 正午锚点，避免手工换算秒数。
-    private static let unixEpochNoonUTC: Date = {
-        var components = DateComponents()
-        components.timeZone = .gmt
-        components.year = 1970
-        components.month = 1
-        components.day = 1
-        components.hour = 12
-
-        guard let date = gregorianCalendar.date(from: components) else {
-            preconditionFailure("无法构造 Unix epoch 的 UTC 正午日期")
-        }
-        return date
-    }()
-
     public static func yearTitle(lunarYearNumber: Int) -> String {
         if lunarYearNumber > 0 {
             "公元 \(lunarYearNumber) 年"
@@ -161,15 +143,7 @@ public enum LunarCalendarFormatting {
 
     /// 将整数 JDN 转为其对应的 UTC 正午；这符合 JDN 的日界线定义，并避免把纯日期锚定在午夜边界。
     public static func civilDate(fromJulianDayNumber julianDayNumber: Int) -> Date {
-        let daysSinceUnixEpoch = julianDayNumber - unixEpochJulianDayNumber
-        guard let date = gregorianCalendar.date(
-            byAdding: .day,
-            value: daysSinceUnixEpoch,
-            to: unixEpochNoonUTC
-        ) else {
-            preconditionFailure("无法将 JDN \(julianDayNumber) 转换为 Foundation Date")
-        }
-        return date
+        JulianDayNumber.dateAtNoonUTC(for: julianDayNumber)
     }
 
     private static func sexagenaryName(stemIndex: Int, branchIndex: Int) -> String {

--- a/Sources/ChineseCalendarCore/Tests/JulianDayNumberTests.swift
+++ b/Sources/ChineseCalendarCore/Tests/JulianDayNumberTests.swift
@@ -1,0 +1,69 @@
+@testable import ChineseCalendarCore
+import Foundation
+import Testing
+
+@Test func localGregorianDateUsesTheUsersTimeZone() throws {
+    let date = utcDate(year: 2026, month: 1, day: 1, hour: 4)
+    let utcPlusEight = try #require(TimeZone(secondsFromGMT: 8 * 60 * 60))
+    let utcMinusEight = try #require(TimeZone(secondsFromGMT: -8 * 60 * 60))
+
+    #expect(JulianDayNumber.forLocalGregorianDate(
+        containing: date,
+        timeZone: utcPlusEight
+    ) == 2_461_042)
+    #expect(JulianDayNumber.forLocalGregorianDate(
+        containing: date,
+        timeZone: utcMinusEight
+    ) == 2_461_041)
+}
+
+@Test(
+    "本地午夜切换 JDN",
+    arguments: [
+        (8 * 60 * 60, 2025, 12, 31, 16),
+        (-8 * 60 * 60, 2026, 1, 1, 8)
+    ]
+)
+func localMidnightAdvancesJulianDayNumber(
+    secondsFromGMT: Int,
+    year: Int,
+    month: Int,
+    day: Int,
+    utcHourAtLocalMidnight: Int
+) throws {
+    let timeZone = try #require(TimeZone(secondsFromGMT: secondsFromGMT))
+    let localMidnight = utcDate(
+        year: year,
+        month: month,
+        day: day,
+        hour: utcHourAtLocalMidnight
+    )
+
+    let beforeMidnight = JulianDayNumber.forLocalGregorianDate(
+        containing: localMidnight.addingTimeInterval(-1),
+        timeZone: timeZone
+    )
+    let atMidnight = JulianDayNumber.forLocalGregorianDate(
+        containing: localMidnight,
+        timeZone: timeZone
+    )
+
+    #expect(atMidnight == beforeMidnight + 1)
+}
+
+private func utcDate(year: Int, month: Int, day: Int, hour: Int) -> Date {
+    var calendar = Calendar(identifier: .gregorian)
+    calendar.timeZone = .gmt
+
+    var components = DateComponents()
+    components.timeZone = .gmt
+    components.year = year
+    components.month = month
+    components.day = day
+    components.hour = hour
+
+    guard let date = calendar.date(from: components) else {
+        preconditionFailure("无法构造测试日期")
+    }
+    return date
+}

--- a/Sources/ChineseCalendarUI/Calendar/YearDetail/LunarYearDetailView.swift
+++ b/Sources/ChineseCalendarUI/Calendar/YearDetail/LunarYearDetailView.swift
@@ -12,18 +12,20 @@ struct LunarYearDetailView: View {
     let initialDayIndex: Int?
 
     @State private var browseState: LunarCalendarBrowseState
+    @State private var todayJulianDayNumber = JulianDayNumber.forLocalGregorianDate(containing: .now)
+    @State private var todaySelection: CalendarTodaySelection?
 
     @Environment(CalendarRouter.self) private var router
     @Environment(\.calendarStoreContentLevel) private var storeContentLevel
+    @Environment(\.modelContext) private var modelContext
+    @Environment(\.scenePhase) private var scenePhase
     @Query(sort: \ChineseLunarYear.lunarYearNumber) private var years: [ChineseLunarYear]
     @Query(sort: \ChineseLunarMonth.lunarMonthIndex) private var calendarMonths: [ChineseLunarMonth]
-    @Query private var todayCivilDates: [CivilDate]
 
     init(
         initialYearNumber: Int,
         initialMonthIndex: Int? = nil,
-        initialDayIndex: Int? = nil,
-        today: Date = .now
+        initialDayIndex: Int? = nil
     ) {
         self.initialYearNumber = initialYearNumber
         self.initialMonthIndex = initialMonthIndex
@@ -34,21 +36,6 @@ struct LunarYearDetailView: View {
                 selectedMonthIndex: initialMonthIndex,
                 selectedDayIndex: initialDayIndex
             )
-        )
-
-        let todayComponents = Self.gregorianDateComponents(for: today)
-        let todayYear = todayComponents.year ?? 0
-        let todayMonth = todayComponents.month ?? 0
-        let todayDay = todayComponents.day ?? 0
-        let gregorianCalendarStyle = CivilCalendarStyle.gregorian.rawValue
-        _todayCivilDates = Query(
-            filter: #Predicate<CivilDate> { civilDate in
-                civilDate.year == todayYear
-                    && civilDate.month == todayMonth
-                    && civilDate.dayOfMonth == todayDay
-                    && civilDate.calendarStyleRawValue == gregorianCalendarStyle
-            },
-            sort: \CivilDate.dayIndex
         )
     }
 
@@ -70,7 +57,7 @@ struct LunarYearDetailView: View {
                                 months: monthsInYearStartOrder,
                                 month: selectedMonth,
                                 daySelection: browseState.daySelection,
-                                todayDayIndex: todayCivilDates.first?.dayIndex,
+                                todayJulianDayNumber: todayJulianDayNumber,
                                 showYearPicker: presentYearPicker,
                                 canSelectPreviousMonth: canSelect(adjacentMonths.previous),
                                 canSelectNextMonth: canSelect(adjacentMonths.next),
@@ -93,15 +80,23 @@ struct LunarYearDetailView: View {
             }
         }
         .background(.calendarSystemBackground)
-        .onAppear(perform: selectDefaultMonthIfNeeded)
+        .onAppear(perform: refreshToday)
         .onChange(of: browseState.displayedYearNumber) {
             selectDefaultMonthIfNeeded()
         }
-        .onChange(of: todayCivilDates.map(\.dayIndex)) {
-            selectDefaultMonthIfNeeded()
-        }
         .onChange(of: storeContentLevel) {
-            selectDefaultMonthIfNeeded()
+            refreshToday()
+        }
+        .onChange(of: scenePhase) {
+            if scenePhase == .active {
+                refreshToday()
+            }
+        }
+        .onReceive(NotificationCenter.default.publisher(for: .NSCalendarDayChanged)) { _ in
+            refreshToday()
+        }
+        .onReceive(NotificationCenter.default.publisher(for: .NSSystemTimeZoneDidChange)) { _ in
+            refreshToday()
         }
         .navigationTitle("日历")
         .toolbar {
@@ -176,28 +171,49 @@ private extension LunarYearDetailView {
         return todaySelection.lunarMonthIndex
     }
 
-    var todaySelection: CalendarTodaySelection? {
-        todayCivilDates
-            .lazy
-            .compactMap { civilDate -> CalendarTodaySelection? in
-                guard let lunarDay = civilDate.calendarDay?.chineseLunarDay else {
-                    return nil
-                }
+    func refreshToday() {
+        let julianDayNumber = JulianDayNumber.forLocalGregorianDate(containing: .now)
+        todayJulianDayNumber = julianDayNumber
+        todaySelection = loadTodaySelection(julianDayNumber: julianDayNumber)
+        selectDefaultMonthIfNeeded()
+    }
 
-                let lunarYearNumber = lunarDay.chineseLunarMonth?.lunarYearNumber
-                    ?? calendarMonths.first { $0.lunarMonthIndex == lunarDay.lunarMonthIndex }?.lunarYearNumber
-
-                guard let lunarYearNumber else {
-                    return nil
-                }
-
-                return CalendarTodaySelection(
-                    lunarYearNumber: lunarYearNumber,
-                    lunarMonthIndex: lunarDay.lunarMonthIndex,
-                    dayIndex: lunarDay.dayIndex
-                )
+    func loadTodaySelection(julianDayNumber: Int) -> CalendarTodaySelection? {
+        var descriptor = FetchDescriptor<CalendarDay>(
+            predicate: #Predicate<CalendarDay> { calendarDay in
+                calendarDay.julianDayNumber == julianDayNumber
             }
-            .first
+        )
+        descriptor.fetchLimit = 1
+        descriptor.relationshipKeyPathsForPrefetching = [\.chineseLunarDay]
+
+        let calendarDay: CalendarDay
+        do {
+            guard let fetchedCalendarDay = try modelContext.fetch(descriptor).first else {
+                return nil
+            }
+            calendarDay = fetchedCalendarDay
+        } catch {
+            ChineseCalendarLog.ui.error("无法按 JDN 查询今天：\(error.localizedDescription)")
+            return nil
+        }
+
+        guard let lunarDay = calendarDay.chineseLunarDay else {
+            return nil
+        }
+
+        let lunarYearNumber = lunarDay.chineseLunarMonth?.lunarYearNumber
+            ?? calendarMonths.first { $0.lunarMonthIndex == lunarDay.lunarMonthIndex }?.lunarYearNumber
+
+        guard let lunarYearNumber else {
+            return nil
+        }
+
+        return CalendarTodaySelection(
+            lunarYearNumber: lunarYearNumber,
+            lunarMonthIndex: lunarDay.lunarMonthIndex,
+            dayIndex: lunarDay.dayIndex
+        )
     }
 
     func selectDefaultMonthIfNeeded() {
@@ -301,6 +317,7 @@ private extension LunarYearDetailView {
     }
 
     func selectToday() {
+        refreshToday()
         guard let todaySelection else {
             selectYear(ChineseLunarCalendar.yearNumber())
             return
@@ -341,13 +358,5 @@ private extension LunarYearDetailView {
                 in: Array(destinationMonthIndices)
             )
         )
-    }
-}
-
-private extension LunarYearDetailView {
-    static func gregorianDateComponents(for date: Date) -> DateComponents {
-        var calendar = Calendar(identifier: .gregorian)
-        calendar.timeZone = .autoupdatingCurrent
-        return calendar.dateComponents([.year, .month, .day], from: date)
     }
 }

--- a/Sources/ChineseCalendarUI/Calendar/YearDetail/LunarYearDetailView.swift
+++ b/Sources/ChineseCalendarUI/Calendar/YearDetail/LunarYearDetailView.swift
@@ -202,8 +202,12 @@ private extension LunarYearDetailView {
             return nil
         }
 
+        let fallbackMonthIndex = calendarMonths.binarySearchIndex(
+            of: lunarDay.lunarMonthIndex,
+            by: \.lunarMonthIndex
+        )
         let lunarYearNumber = lunarDay.chineseLunarMonth?.lunarYearNumber
-            ?? calendarMonths.first { $0.lunarMonthIndex == lunarDay.lunarMonthIndex }?.lunarYearNumber
+            ?? fallbackMonthIndex.map { calendarMonths[$0].lunarYearNumber }
 
         guard let lunarYearNumber else {
             return nil

--- a/Sources/ChineseCalendarUI/Calendar/YearDetail/LunarYearDetailView.swift
+++ b/Sources/ChineseCalendarUI/Calendar/YearDetail/LunarYearDetailView.swift
@@ -1,6 +1,7 @@
 import ChineseCalendarCore
 import ChineseCalendarLogging
 import ChineseCalendarPersistence
+import Combine
 import SFSafeSymbols
 import SwiftData
 import SwiftUI
@@ -92,10 +93,16 @@ struct LunarYearDetailView: View {
                 refreshToday()
             }
         }
-        .onReceive(NotificationCenter.default.publisher(for: .NSCalendarDayChanged)) { _ in
+        .onReceive(
+            NotificationCenter.default.publisher(for: .NSCalendarDayChanged)
+                .receive(on: RunLoop.main)
+        ) { _ in
             refreshToday()
         }
-        .onReceive(NotificationCenter.default.publisher(for: .NSSystemTimeZoneDidChange)) { _ in
+        .onReceive(
+            NotificationCenter.default.publisher(for: .NSSystemTimeZoneDidChange)
+                .receive(on: RunLoop.main)
+        ) { _ in
             refreshToday()
         }
         .navigationTitle("日历")

--- a/Sources/ChineseCalendarUI/Calendar/YearDetail/Month/LunarMonthGrid.swift
+++ b/Sources/ChineseCalendarUI/Calendar/YearDetail/Month/LunarMonthGrid.swift
@@ -16,7 +16,7 @@ struct LunarMonthGrid: View {
     let selectPreviousMonth: () -> Void
     let selectNextMonth: () -> Void
     let selectMonth: (ChineseLunarMonth) -> Void
-    let todayDayIndex: Int?
+    let todayJulianDayNumber: Int
     let yearTransitionContext: LunarYearTransitionContext
 
     @Environment(\.calendarStoreContentLevel) private var storeContentLevel
@@ -29,7 +29,7 @@ struct LunarMonthGrid: View {
         months: [ChineseLunarMonth],
         month: ChineseLunarMonth,
         daySelection: CalendarDaySelection,
-        todayDayIndex: Int?,
+        todayJulianDayNumber: Int,
         showYearPicker: (() -> Void)? = nil,
         canSelectPreviousMonth: Bool,
         canSelectNextMonth: Bool,
@@ -42,7 +42,7 @@ struct LunarMonthGrid: View {
         self.months = months
         self.month = month
         self.daySelection = daySelection
-        self.todayDayIndex = todayDayIndex
+        self.todayJulianDayNumber = todayJulianDayNumber
         self.showYearPicker = showYearPicker
         self.canSelectPreviousMonth = canSelectPreviousMonth
         self.canSelectNextMonth = canSelectNextMonth
@@ -62,16 +62,13 @@ struct LunarMonthGrid: View {
 
     var body: some View {
         let selectedDayIndex = daySelection.dayIndex
-        let todayDay = todayDayIndex.flatMap { todayDayIndex in
-            days.first { $0.dayIndex == todayDayIndex }
-        }
+        let todayDay = days.first { $0.calendarDay?.julianDayNumber == todayJulianDayNumber }
         let defaultSelectedDay = todayDay ?? days.first
         let selectedDay = selectedDay(
             at: selectedDayIndex,
             defaultingTo: defaultSelectedDay
         )
         let effectiveSelectedDayIndex = selectedDay?.dayIndex
-        let todayDayIndex = todayDay?.dayIndex
 
         VStack(alignment: .leading, spacing: 16) {
             MonthSwitcher(
@@ -125,7 +122,7 @@ struct LunarMonthGrid: View {
                                 LunarDayGridCell(
                                     day: day,
                                     isSelected: day.dayIndex == effectiveSelectedDayIndex,
-                                    isToday: day.dayIndex == todayDayIndex
+                                    isToday: day.calendarDay?.julianDayNumber == todayJulianDayNumber
                                 )
                             }
                             .buttonStyle(.plain)
@@ -147,6 +144,9 @@ struct LunarMonthGrid: View {
         .onAppear(perform: finishPendingMonthSwitch)
         .onChange(of: days.map(\.dayIndex)) {
             finishPendingMonthSwitch()
+        }
+        .onChange(of: todayJulianDayNumber) {
+            selectDefaultDayIfNeeded()
         }
     }
 
@@ -239,8 +239,13 @@ struct LunarMonthGrid: View {
         }
 
         daySelection.dayIndex = Self.defaultDayIndex(
-            in: days.map(\.dayIndex),
-            todayDayIndex: todayDayIndex
+            in: days.map { day in
+                (
+                    dayIndex: day.dayIndex,
+                    julianDayNumber: day.calendarDay?.julianDayNumber
+                )
+            },
+            todayJulianDayNumber: todayJulianDayNumber
         )
     }
 
@@ -265,11 +270,15 @@ struct LunarMonthGrid: View {
         civilDateRangeTitle ?? fallback
     }
 
-    static func defaultDayIndex(in dayIndices: [Int], todayDayIndex: Int?) -> Int? {
-        if let todayDayIndex, dayIndices.contains(todayDayIndex) {
-            return todayDayIndex
+    static func defaultDayIndex(
+        in days: [(dayIndex: Int, julianDayNumber: Int?)],
+        todayJulianDayNumber: Int?
+    ) -> Int? {
+        guard let todayJulianDayNumber else {
+            return days.first?.dayIndex
         }
 
-        return dayIndices.first
+        return days.first(where: { $0.julianDayNumber == todayJulianDayNumber })?.dayIndex
+            ?? days.first?.dayIndex
     }
 }

--- a/Sources/ChineseCalendarUI/Tests/LunarMonthGridTests.swift
+++ b/Sources/ChineseCalendarUI/Tests/LunarMonthGridTests.swift
@@ -25,8 +25,12 @@ import Testing
 
 @Test func defaultDaySelectionPrefersTodayWhenItBelongsToTheMonth() {
     let selectedDayIndex = LunarMonthGrid.defaultDayIndex(
-        in: [101, 102, 103],
-        todayDayIndex: 102
+        in: [
+            (dayIndex: 101, julianDayNumber: 2_461_041),
+            (dayIndex: 102, julianDayNumber: 2_461_042),
+            (dayIndex: 103, julianDayNumber: 2_461_043)
+        ],
+        todayJulianDayNumber: 2_461_042
     )
 
     #expect(selectedDayIndex == 102)
@@ -34,8 +38,12 @@ import Testing
 
 @Test func defaultDaySelectionUsesFirstDayWhenTodayIsOutsideTheMonth() {
     let selectedDayIndex = LunarMonthGrid.defaultDayIndex(
-        in: [101, 102, 103],
-        todayDayIndex: 999
+        in: [
+            (dayIndex: 101, julianDayNumber: 2_461_041),
+            (dayIndex: 102, julianDayNumber: 2_461_042),
+            (dayIndex: 103, julianDayNumber: 2_461_043)
+        ],
+        todayJulianDayNumber: 2_461_099
     )
 
     #expect(selectedDayIndex == 101)
@@ -44,7 +52,7 @@ import Testing
 @Test func defaultDaySelectionIsNilForAnEmptyMonth() {
     let selectedDayIndex = LunarMonthGrid.defaultDayIndex(
         in: [],
-        todayDayIndex: 102
+        todayJulianDayNumber: 2_461_042
     )
 
     #expect(selectedDayIndex == nil)


### PR DESCRIPTION
## Summary

- 新增集中、可测试的用户本地 Gregorian 日期到 JDN 转换，并复用 UTC 正午 JDN 转换
- 通过唯一的 CalendarDay.julianDayNumber 查询今天，不再按 CivilDate 四字段定位
- 网格直接比较 JDN 判断 isToday，并保留当前月份优先选择今天的行为
- 在跨本地午夜、系统时区变化、App 回到 active 和点击今天时刷新
- 覆盖 UTC+8、UTC-8 与本地午夜边界测试

## Validation

- SwiftPM：85 tests passed
- SwiftFormat：0/116 files require formatting
- SwiftLint：0 violations in 106 files
- git diff --check
- XcodeBuildMCP：ChineseCalendar-iOS 在 chinesedate iPhone 17 Pro Max 构建运行成功
- Simulator：从农历六月点击今天后返回农历七月，8 月 25 日显示十三，今天；后台恢复后标记保持正确

Closes #103