### PR TITLE
拆分月份切换器与日期网格

### DIFF
--- a/Sources/ChineseCalendarUI/Calendar/YearDetail/LunarYearDetailView.swift
+++ b/Sources/ChineseCalendarUI/Calendar/YearDetail/LunarYearDetailView.swift
@@ -53,22 +53,30 @@ struct LunarYearDetailView: View {
                                 Label("没有月份数据", systemSymbol: .calendarBadgeExclamationmark)
                             }
                         } else if let selectedMonth {
-                            LunarMonthGrid(
-                                year: year,
-                                months: monthsInYearStartOrder,
-                                month: selectedMonth,
-                                daySelection: browseState.daySelection,
-                                todayJulianDayNumber: todayJulianDayNumber,
-                                showYearPicker: presentYearPicker,
-                                canSelectPreviousMonth: canSelect(adjacentMonths.previous),
-                                canSelectNextMonth: canSelect(adjacentMonths.next),
-                                selectPreviousMonth: { selectMonthInCalendar(adjacentMonths.previous) },
-                                selectNextMonth: { selectMonthInCalendar(adjacentMonths.next) },
-                                selectMonth: selectMonthInCalendar,
-                                yearTransitionContext: browseState.yearTransitionContext,
-                                yearTransitionPreparationMonthIndex: pendingYearTransition?.sourceMonthIndex,
-                                completeYearTransitionPreparation: completeYearTransitionPreparation
-                            )
+                            VStack(alignment: .leading, spacing: 16) {
+                                MonthSwitcher(
+                                    year: year,
+                                    months: monthsInYearStartOrder,
+                                    selectedMonth: selectedMonth,
+                                    showYearPicker: presentYearPicker,
+                                    canSelectPreviousMonth: canSelect(adjacentMonths.previous),
+                                    canSelectNextMonth: canSelect(adjacentMonths.next),
+                                    selectPreviousMonth: { selectMonthInCalendar(adjacentMonths.previous) },
+                                    selectNextMonth: { selectMonthInCalendar(adjacentMonths.next) },
+                                    selectMonth: selectMonthInCalendar,
+                                    yearTransitionContext: browseState.yearTransitionContext,
+                                    yearTransitionPreparationMonthIndex: pendingYearTransition?.sourceMonthIndex,
+                                    completeYearTransitionPreparation: completeYearTransitionPreparation
+                                )
+                                .padding()
+                                .background(.background.secondary, in: RoundedRectangle(cornerRadius: 28))
+
+                                LunarMonthGrid(
+                                    month: selectedMonth,
+                                    daySelection: browseState.daySelection,
+                                    todayJulianDayNumber: todayJulianDayNumber
+                                )
+                            }
                         }
                     }
                     .padding()

--- a/Sources/ChineseCalendarUI/Calendar/YearDetail/Month/LunarMonthGrid.swift
+++ b/Sources/ChineseCalendarUI/Calendar/YearDetail/Month/LunarMonthGrid.swift
@@ -1,61 +1,27 @@
-import ChineseCalendarCore
 import ChineseCalendarLogging
 import ChineseCalendarPersistence
 import SFSafeSymbols
 import SwiftData
 import SwiftUI
 
-/// 显示在 LunarYearDetailView 中，用于浏览当前月份的日期网格与选中日详情。
+/// 显示指定农历月的日期网格与选中日详情。
 struct LunarMonthGrid: View {
-    let year: ChineseLunarYear
-    let months: [ChineseLunarMonth]
-    let month: ChineseLunarMonth
-    let showYearPicker: (() -> Void)?
-    let canSelectPreviousMonth: Bool
-    let canSelectNextMonth: Bool
-    let selectPreviousMonth: () -> Void
-    let selectNextMonth: () -> Void
-    let selectMonth: (ChineseLunarMonth) -> Void
-    let todayJulianDayNumber: Int
-    let yearTransitionContext: LunarYearTransitionContext
-    let yearTransitionPreparationMonthIndex: Int?
-    let completeYearTransitionPreparation: (Int) -> Void
-
     @Environment(\.calendarStoreContentLevel) private var storeContentLevel
-    @Environment(\.locale) private var locale
+
+    let month: ChineseLunarMonth
+    let todayJulianDayNumber: Int
+
     @Bindable var daySelection: CalendarDaySelection
     @Query private var days: [ChineseLunarDay]
 
     init(
-        year: ChineseLunarYear,
-        months: [ChineseLunarMonth],
         month: ChineseLunarMonth,
         daySelection: CalendarDaySelection,
-        todayJulianDayNumber: Int,
-        showYearPicker: (() -> Void)? = nil,
-        canSelectPreviousMonth: Bool,
-        canSelectNextMonth: Bool,
-        selectPreviousMonth: @escaping () -> Void,
-        selectNextMonth: @escaping () -> Void,
-        selectMonth: @escaping (ChineseLunarMonth) -> Void,
-        yearTransitionContext: LunarYearTransitionContext,
-        yearTransitionPreparationMonthIndex: Int?,
-        completeYearTransitionPreparation: @escaping (Int) -> Void
+        todayJulianDayNumber: Int
     ) {
-        self.year = year
-        self.months = months
         self.month = month
         self.daySelection = daySelection
         self.todayJulianDayNumber = todayJulianDayNumber
-        self.showYearPicker = showYearPicker
-        self.canSelectPreviousMonth = canSelectPreviousMonth
-        self.canSelectNextMonth = canSelectNextMonth
-        self.selectPreviousMonth = selectPreviousMonth
-        self.selectNextMonth = selectNextMonth
-        self.selectMonth = selectMonth
-        self.yearTransitionContext = yearTransitionContext
-        self.yearTransitionPreparationMonthIndex = yearTransitionPreparationMonthIndex
-        self.completeYearTransitionPreparation = completeYearTransitionPreparation
 
         let lunarMonthIndex = month.lunarMonthIndex
         _days = Query(
@@ -77,25 +43,6 @@ struct LunarMonthGrid: View {
         let effectiveSelectedDayIndex = selectedDay?.dayIndex
 
         VStack(alignment: .leading, spacing: 16) {
-            MonthSwitcher(
-                title: monthNavigationTitle,
-                subtitle: monthNavigationSubtitle,
-                yearNumber: year.lunarYearNumber,
-                months: months,
-                selectedMonth: month,
-                showYearPicker: showYearPicker,
-                canSelectPreviousMonth: canSelectPreviousMonth,
-                canSelectNextMonth: canSelectNextMonth,
-                selectPreviousMonth: selectPreviousMonth,
-                selectNextMonth: selectNextMonth,
-                selectMonth: selectMonth,
-                yearTransitionContext: yearTransitionContext,
-                yearTransitionPreparationMonthIndex: yearTransitionPreparationMonthIndex,
-                completeYearTransitionPreparation: completeYearTransitionPreparation
-            )
-            .padding()
-            .background(.background.secondary, in: RoundedRectangle(cornerRadius: 28))
-
             if days.isEmpty {
                 ContentUnavailableView(
                     label: {
@@ -173,40 +120,6 @@ struct LunarMonthGrid: View {
         return defaultSelectedDay
     }
 
-    private var monthNavigationTitle: String {
-        let yearTitle = LunarCalendarFormatting.yearSubtitle(
-            stemIndex: year.yearStemIndex,
-            branchIndex: year.yearBranchIndex
-        )
-        return "\(yearTitle) \(LunarMonthDisplay.title(for: month))"
-    }
-
-    private var monthNavigationSubtitle: String {
-        let fallback = LunarCalendarFormatting.monthSubtitle(
-            dayCount: month.dayCount,
-            stemIndex: month.monthStemIndex,
-            branchIndex: month.monthBranchIndex
-        )
-        return Self.monthNavigationSubtitle(
-            civilDateRangeTitle: civilDateRangeTitle,
-            fallback: fallback
-        )
-    }
-
-    private var civilDateRangeTitle: String? {
-        guard let firstJulianDayNumber = days.first?.calendarDay?.julianDayNumber,
-              let lastJulianDayNumber = days.last?.calendarDay?.julianDayNumber
-        else {
-            return nil
-        }
-
-        return LunarCalendarFormatting.civilDateRangeTitle(
-            fromJulianDayNumber: firstJulianDayNumber,
-            throughJulianDayNumber: lastJulianDayNumber,
-            locale: locale
-        )
-    }
-
     private var emptyStateTitle: String {
         switch storeContentLevel {
         case .base:
@@ -273,13 +186,6 @@ struct LunarMonthGrid: View {
 }
 
 extension LunarMonthGrid {
-    static func monthNavigationSubtitle(
-        civilDateRangeTitle: String?,
-        fallback: String
-    ) -> String {
-        civilDateRangeTitle ?? fallback
-    }
-
     static func defaultDayIndex(
         in days: [(dayIndex: Int, julianDayNumber: Int?)],
         todayJulianDayNumber: Int?

--- a/Sources/ChineseCalendarUI/Calendar/YearDetail/Month/MonthSwitcher.swift
+++ b/Sources/ChineseCalendarUI/Calendar/YearDetail/Month/MonthSwitcher.swift
@@ -87,16 +87,14 @@ struct MonthSwitcher: View {
     }
 
     private var civilDateRangeTitle: String? {
-        let days = selectedMonth.days.sorted { $0.dayNumberInMonth < $1.dayNumberInMonth }
-        guard let firstJulianDayNumber = days.first?.calendarDay?.julianDayNumber,
-              let lastJulianDayNumber = days.last?.calendarDay?.julianDayNumber
-        else {
+        let julianDayNumbers = selectedMonth.days.map { $0.calendarDay?.julianDayNumber }
+        guard let julianDayRange = Self.julianDayRange(in: julianDayNumbers) else {
             return nil
         }
 
         return LunarCalendarFormatting.civilDateRangeTitle(
-            fromJulianDayNumber: firstJulianDayNumber,
-            throughJulianDayNumber: lastJulianDayNumber,
+            fromJulianDayNumber: julianDayRange.lowerBound,
+            throughJulianDayNumber: julianDayRange.upperBound,
             locale: locale
         )
     }
@@ -143,6 +141,17 @@ struct MonthSwitcher: View {
 }
 
 extension MonthSwitcher {
+    static func julianDayRange(in julianDayNumbers: [Int?]) -> ClosedRange<Int>? {
+        let availableJulianDayNumbers = julianDayNumbers.compactMap(\.self)
+        guard let firstJulianDayNumber = availableJulianDayNumbers.min(),
+              let lastJulianDayNumber = availableJulianDayNumbers.max()
+        else {
+            return nil
+        }
+
+        return firstJulianDayNumber ... lastJulianDayNumber
+    }
+
     static func monthNavigationSubtitle(
         civilDateRangeTitle: String?,
         fallback: String

--- a/Sources/ChineseCalendarUI/Calendar/YearDetail/Month/MonthSwitcher.swift
+++ b/Sources/ChineseCalendarUI/Calendar/YearDetail/Month/MonthSwitcher.swift
@@ -3,11 +3,12 @@ import ChineseCalendarPersistence
 import SFSafeSymbols
 import SwiftUI
 
-/// 显示在 LunarMonthGrid 顶部，用于切换当前查看的农历月份。
+/// 显示在 LunarYearDetailView 中，用于切换当前查看的农历月份。
 struct MonthSwitcher: View {
-    let title: String
-    let subtitle: String
-    let yearNumber: Int
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @Environment(\.locale) private var locale
+
+    let year: ChineseLunarYear
     let months: [ChineseLunarMonth]
     let selectedMonth: ChineseLunarMonth
     let showYearPicker: (() -> Void)?
@@ -19,8 +20,6 @@ struct MonthSwitcher: View {
     let yearTransitionContext: LunarYearTransitionContext
     let yearTransitionPreparationMonthIndex: Int?
     let completeYearTransitionPreparation: (Int) -> Void
-
-    @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {
@@ -35,11 +34,11 @@ struct MonthSwitcher: View {
 
                 ZStack(alignment: .leading) {
                     titleContent
-                        .id(yearNumber)
+                        .id(year.lunarYearNumber)
                         .transition(yearTransition)
                 }
                 .clipped()
-                .animation(yearSelectionAnimation, value: yearNumber)
+                .animation(yearSelectionAnimation, value: year.lunarYearNumber)
                 .frame(maxWidth: .infinity, alignment: .leading)
 
                 Button("下个月", systemSymbol: .chevronRight, action: selectNextMonth)
@@ -59,12 +58,47 @@ struct MonthSwitcher: View {
                     yearTransitionPreparationMonthIndex: yearTransitionPreparationMonthIndex,
                     completeYearTransitionPreparation: completeYearTransitionPreparation
                 )
-                .id(yearNumber)
+                .id(year.lunarYearNumber)
                 .transition(yearTransition)
             }
             .clipped()
-            .animation(yearSelectionAnimation, value: yearNumber)
+            .animation(yearSelectionAnimation, value: year.lunarYearNumber)
         }
+    }
+
+    private var monthNavigationTitle: String {
+        let yearTitle = LunarCalendarFormatting.yearSubtitle(
+            stemIndex: year.yearStemIndex,
+            branchIndex: year.yearBranchIndex
+        )
+        return "\(yearTitle) \(LunarMonthDisplay.title(for: selectedMonth))"
+    }
+
+    private var monthNavigationSubtitle: String {
+        let fallback = LunarCalendarFormatting.monthSubtitle(
+            dayCount: selectedMonth.dayCount,
+            stemIndex: selectedMonth.monthStemIndex,
+            branchIndex: selectedMonth.monthBranchIndex
+        )
+        return Self.monthNavigationSubtitle(
+            civilDateRangeTitle: civilDateRangeTitle,
+            fallback: fallback
+        )
+    }
+
+    private var civilDateRangeTitle: String? {
+        let days = selectedMonth.days.sorted { $0.dayNumberInMonth < $1.dayNumberInMonth }
+        guard let firstJulianDayNumber = days.first?.calendarDay?.julianDayNumber,
+              let lastJulianDayNumber = days.last?.calendarDay?.julianDayNumber
+        else {
+            return nil
+        }
+
+        return LunarCalendarFormatting.civilDateRangeTitle(
+            fromJulianDayNumber: firstJulianDayNumber,
+            throughJulianDayNumber: lastJulianDayNumber,
+            locale: locale
+        )
     }
 
     private var yearTransition: AnyTransition {
@@ -97,13 +131,22 @@ struct MonthSwitcher: View {
 
     private var monthTitleContent: some View {
         VStack(alignment: .leading, spacing: 4) {
-            Text(title)
+            Text(monthNavigationTitle)
                 .font(.title2)
                 .bold()
-            Text(subtitle)
+            Text(monthNavigationSubtitle)
                 .font(.subheadline)
                 .foregroundStyle(.secondary)
         }
         .accessibilityElement(children: .combine)
+    }
+}
+
+extension MonthSwitcher {
+    static func monthNavigationSubtitle(
+        civilDateRangeTitle: String?,
+        fallback: String
+    ) -> String {
+        civilDateRangeTitle ?? fallback
     }
 }

--- a/Sources/ChineseCalendarUI/Calendar/YearDetail/Month/MonthSwitcher.swift
+++ b/Sources/ChineseCalendarUI/Calendar/YearDetail/Month/MonthSwitcher.swift
@@ -143,13 +143,13 @@ struct MonthSwitcher: View {
 extension MonthSwitcher {
     static func julianDayRange(in julianDayNumbers: [Int?]) -> ClosedRange<Int>? {
         let availableJulianDayNumbers = julianDayNumbers.compactMap(\.self)
-        guard let firstJulianDayNumber = availableJulianDayNumbers.min(),
-              let lastJulianDayNumber = availableJulianDayNumbers.max()
+        guard let minimumJulianDayNumber = availableJulianDayNumbers.min(),
+              let maximumJulianDayNumber = availableJulianDayNumbers.max()
         else {
             return nil
         }
 
-        return firstJulianDayNumber ... lastJulianDayNumber
+        return minimumJulianDayNumber ... maximumJulianDayNumber
     }
 
     static func monthNavigationSubtitle(

--- a/Sources/ChineseCalendarUI/Tests/LunarMonthGridTests.swift
+++ b/Sources/ChineseCalendarUI/Tests/LunarMonthGridTests.swift
@@ -1,28 +1,6 @@
 @testable import ChineseCalendarUI
 import Testing
 
-@Test func monthNavigationSubtitleShowsOnlyCivilDateRangeWhenAvailable() {
-    let dateRange = "公元前 221-01-01 – 221-01-28"
-
-    let subtitle = LunarMonthGrid.monthNavigationSubtitle(
-        civilDateRangeTitle: dateRange,
-        fallback: "27天 · 丙寅月"
-    )
-
-    #expect(subtitle == dateRange)
-    #expect(!subtitle.contains("今天优先选中"))
-    #expect(!subtitle.contains("默认选中初一"))
-}
-
-@Test func monthNavigationSubtitleUsesMonthSummaryWithoutCivilDates() {
-    let subtitle = LunarMonthGrid.monthNavigationSubtitle(
-        civilDateRangeTitle: nil,
-        fallback: "27天 · 丙寅月"
-    )
-
-    #expect(subtitle == "27天 · 丙寅月")
-}
-
 @Test func defaultDaySelectionPrefersTodayWhenItBelongsToTheMonth() {
     let selectedDayIndex = LunarMonthGrid.defaultDayIndex(
         in: [

--- a/Sources/ChineseCalendarUI/Tests/MonthSwitcherTests.swift
+++ b/Sources/ChineseCalendarUI/Tests/MonthSwitcherTests.swift
@@ -1,0 +1,24 @@
+@testable import ChineseCalendarUI
+import Testing
+
+@Test func monthNavigationSubtitleShowsOnlyCivilDateRangeWhenAvailable() {
+    let dateRange = "公元前 221-01-01 – 221-01-28"
+
+    let subtitle = MonthSwitcher.monthNavigationSubtitle(
+        civilDateRangeTitle: dateRange,
+        fallback: "27天 · 丙寅月"
+    )
+
+    #expect(subtitle == dateRange)
+    #expect(!subtitle.contains("今天优先选中"))
+    #expect(!subtitle.contains("默认选中初一"))
+}
+
+@Test func monthNavigationSubtitleUsesMonthSummaryWithoutCivilDates() {
+    let subtitle = MonthSwitcher.monthNavigationSubtitle(
+        civilDateRangeTitle: nil,
+        fallback: "27天 · 丙寅月"
+    )
+
+    #expect(subtitle == "27天 · 丙寅月")
+}

--- a/Sources/ChineseCalendarUI/Tests/MonthSwitcherTests.swift
+++ b/Sources/ChineseCalendarUI/Tests/MonthSwitcherTests.swift
@@ -1,6 +1,18 @@
 @testable import ChineseCalendarUI
 import Testing
 
+@Test func julianDayRangeUsesAvailableExtremesRegardlessOfOrder() {
+    let range = MonthSwitcher.julianDayRange(
+        in: [nil, 2_460_900, 2_460_898, nil, 2_460_899]
+    )
+
+    #expect(range == 2_460_898 ... 2_460_900)
+}
+
+@Test func julianDayRangeIsAbsentWithoutCivilDates() {
+    #expect(MonthSwitcher.julianDayRange(in: [nil, nil]) == nil)
+}
+
 @Test func monthNavigationSubtitleShowsOnlyCivilDateRangeWhenAvailable() {
     let dateRange = "公元前 221-01-01 – 221-01-28"
 


### PR DESCRIPTION
## 改动

- 将月份切换、年份选择和跨年过渡协调移出 `LunarMonthGrid`，由 `LunarYearDetailView` 直接组合 `MonthSwitcher` 与日期网格。
- 将 `LunarMonthGrid` 的初始化参数从 14 个缩减为 3 个：`month`、`daySelection`、`todayJulianDayNumber`。
- 将月份标题和公历日期范围副标题迁移到 `MonthSwitcher`，相关测试也随职责迁移。
- 保留现有跨年动画链路：年份页面继续直接协调 `MonthSwitcher` / `LunarMonthStrip`。

## 验证

- `./Scripts/format.sh --check`
- `./Scripts/lint.sh`（0 violations）
- `swift test --package-path Sources`（88 tests passed）
- XcodeBuildMCP build / install / launch 通过
- Simulator 交互验证：月切换、年份选择，以及“今天”返回当前月份并选中今天均正常
