### PR TITLE
收敛 LunarYearDetailView 的年份入口参数

### DIFF
--- a/Sources/ChineseCalendarUI/Calendar/YearDetail/LunarCalendarBrowseState.swift
+++ b/Sources/ChineseCalendarUI/Calendar/YearDetail/LunarCalendarBrowseState.swift
@@ -5,6 +5,7 @@ import Observation
 @Observable
 final class LunarCalendarBrowseState {
     private(set) var displayedYearNumber: Int
+    private var hasAppliedInitialLanding = false
     let yearTransitionContext = LunarYearTransitionContext()
     var yearTransitionDirection: LunarYearTransitionDirection {
         yearTransitionContext.direction
@@ -22,14 +23,22 @@ final class LunarCalendarBrowseState {
 
     let daySelection: CalendarDaySelection
 
-    init(
-        displayedYearNumber: Int,
-        selectedMonthIndex: Int? = nil,
-        selectedDayIndex: Int? = nil
-    ) {
+    init(displayedYearNumber: Int) {
         self.displayedYearNumber = displayedYearNumber
-        self.selectedMonthIndex = selectedMonthIndex
-        daySelection = CalendarDaySelection(dayIndex: selectedDayIndex)
+        daySelection = CalendarDaySelection()
+    }
+
+    /// 只在页面首次进入时应用导航地址，避免 View 重建覆盖后续浏览状态。
+    func applyInitialLanding(
+        monthIndex: Int?,
+        dayIndex: Int?
+    ) {
+        guard !hasAppliedInitialLanding else {
+            return
+        }
+
+        hasAppliedInitialLanding = true
+        select(monthIndex: monthIndex, dayIndex: dayIndex)
     }
 
     func selectYear(_ yearNumber: Int) {

--- a/Sources/ChineseCalendarUI/Calendar/YearDetail/LunarYearDetailView.swift
+++ b/Sources/ChineseCalendarUI/Calendar/YearDetail/LunarYearDetailView.swift
@@ -6,38 +6,27 @@ import SFSafeSymbols
 import SwiftData
 import SwiftUI
 
-/// 从目的地提供的初始日期开始，在页面内部浏览农历年、月与日。
+/// 以所选农历年为业务输入，在显式页面状态中浏览月与日。
 struct LunarYearDetailView: View {
-    let initialYearNumber: Int
-    let initialMonthIndex: Int?
-    let initialDayIndex: Int?
-
-    @State private var browseState: LunarCalendarBrowseState
-    @State private var pendingYearTransition: LunarYearTransitionRequest?
-    @State private var todayJulianDayNumber = JulianDayNumber.forLocalGregorianDate(containing: .now)
-    @State private var todaySelection: CalendarTodaySelection?
-
     @Environment(CalendarRouter.self) private var router
     @Environment(\.calendarStoreContentLevel) private var storeContentLevel
     @Environment(\.modelContext) private var modelContext
     @Environment(\.scenePhase) private var scenePhase
     @Query(sort: \ChineseLunarYear.lunarYearNumber) private var years: [ChineseLunarYear]
 
+    let yearNumber: Int
+
+    @Bindable private var browseState: LunarCalendarBrowseState
+    @State private var pendingYearTransition: LunarYearTransitionRequest?
+    @State private var todayJulianDayNumber = JulianDayNumber.forLocalGregorianDate(containing: .now)
+    @State private var todaySelection: CalendarTodaySelection?
+
     init(
-        initialYearNumber: Int,
-        initialMonthIndex: Int? = nil,
-        initialDayIndex: Int? = nil
+        yearNumber: Int,
+        browseState: LunarCalendarBrowseState
     ) {
-        self.initialYearNumber = initialYearNumber
-        self.initialMonthIndex = initialMonthIndex
-        self.initialDayIndex = initialDayIndex
-        _browseState = State(
-            initialValue: LunarCalendarBrowseState(
-                displayedYearNumber: initialYearNumber,
-                selectedMonthIndex: initialMonthIndex,
-                selectedDayIndex: initialDayIndex
-            )
-        )
+        self.yearNumber = yearNumber
+        self.browseState = browseState
     }
 
     var body: some View {
@@ -92,7 +81,7 @@ struct LunarYearDetailView: View {
         }
         .background(.calendarSystemBackground)
         .onAppear(perform: refreshToday)
-        .onChange(of: browseState.displayedYearNumber) {
+        .onChange(of: yearNumber) {
             selectDefaultMonthIfNeeded()
         }
         .onChange(of: storeContentLevel) {
@@ -141,11 +130,11 @@ struct LunarYearDetailView: View {
 
 private extension LunarYearDetailView {
     var displayedYear: ChineseLunarYear? {
-        years.first { $0.lunarYearNumber == browseState.displayedYearNumber }
+        years.first { $0.lunarYearNumber == yearNumber }
     }
 
     var displayedYearIndex: [ChineseLunarYear].Index? {
-        years.firstIndex { $0.lunarYearNumber == browseState.displayedYearNumber }
+        years.firstIndex { $0.lunarYearNumber == yearNumber }
     }
 
     var canSelectPreviousYear: Bool {
@@ -315,7 +304,7 @@ private extension LunarYearDetailView {
     }
 
     func selectMonthInCalendar(_ month: ChineseLunarMonth) {
-        let crossesYear = month.lunarYearNumber != browseState.displayedYearNumber
+        let crossesYear = month.lunarYearNumber != yearNumber
         guard crossesYear || browseState.selectedMonthIndex != month.lunarMonthIndex else {
             return
         }
@@ -375,7 +364,7 @@ private extension LunarYearDetailView {
 
     func presentYearPicker() {
         let yearPicker = CalendarYearPickerDestination(
-            initialYearNumber: browseState.displayedYearNumber,
+            initialYearNumber: yearNumber,
             onSelect: selectYear
         )
         router.presentSheet(.yearPicker(yearPicker))
@@ -384,7 +373,7 @@ private extension LunarYearDetailView {
     func selectYear(_ yearNumber: Int) {
         guard let destinationYear = years.first(where: { $0.lunarYearNumber == yearNumber }),
               let direction = LunarYearTransitionDirection(
-                  from: browseState.displayedYearNumber,
+                  from: self.yearNumber,
                   to: yearNumber
               )
         else {
@@ -409,7 +398,7 @@ private extension LunarYearDetailView {
         }
 
         pendingYearTransition = LunarYearTransitionRequest(
-            sourceYearNumber: browseState.displayedYearNumber,
+            sourceYearNumber: self.yearNumber,
             sourceMonthIndex: sourceMonthIndex,
             destinationYearNumber: yearNumber,
             destinationMonthIndex: destinationMonthIndex
@@ -419,7 +408,7 @@ private extension LunarYearDetailView {
     func completeYearTransitionPreparation(_ sourceMonthIndex: Int) {
         guard let pendingYearTransition,
               pendingYearTransition.sourceMonthIndex == sourceMonthIndex,
-              pendingYearTransition.sourceYearNumber == browseState.displayedYearNumber
+              pendingYearTransition.sourceYearNumber == yearNumber
         else {
             return
         }

--- a/Sources/ChineseCalendarUI/Home/Navigation/CalendarDestinationView.swift
+++ b/Sources/ChineseCalendarUI/Home/Navigation/CalendarDestinationView.swift
@@ -8,10 +8,10 @@ struct CalendarDestinationView: View {
         Group {
             switch destination {
             case let .lunarYear(yearNumber, monthIndex, dayIndex):
-                LunarYearDetailView(
-                    initialYearNumber: yearNumber,
-                    initialMonthIndex: monthIndex,
-                    initialDayIndex: dayIndex
+                LunarYearDestinationView(
+                    yearNumber: yearNumber,
+                    monthIndex: monthIndex,
+                    dayIndex: dayIndex
                 )
                 .id(destination)
             case let .dynasty(dynastyID):

--- a/Sources/ChineseCalendarUI/Home/Navigation/LunarYearDestinationView.swift
+++ b/Sources/ChineseCalendarUI/Home/Navigation/LunarYearDestinationView.swift
@@ -1,0 +1,23 @@
+import SwiftUI
+
+/// 把年份 destination 的可选月、日地址转换为一次性的页面初始落点。
+struct LunarYearDestinationView: View {
+    @State private var browseState: LunarCalendarBrowseState
+
+    init(
+        yearNumber: Int,
+        monthIndex: Int? = nil,
+        dayIndex: Int? = nil
+    ) {
+        let browseState = LunarCalendarBrowseState(displayedYearNumber: yearNumber)
+        browseState.applyInitialLanding(monthIndex: monthIndex, dayIndex: dayIndex)
+        _browseState = State(initialValue: browseState)
+    }
+
+    var body: some View {
+        LunarYearDetailView(
+            yearNumber: browseState.displayedYearNumber,
+            browseState: browseState
+        )
+    }
+}

--- a/Sources/ChineseCalendarUI/Home/Platform/CalendarHomeSplitView.swift
+++ b/Sources/ChineseCalendarUI/Home/Platform/CalendarHomeSplitView.swift
@@ -22,7 +22,7 @@ struct CalendarHomeSplitView: View {
             .navigationTitle("年份")
         } detail: {
             NavigationStack(path: $router.yearsPath) {
-                LunarYearDetailView(initialYearNumber: ChineseLunarCalendar.yearNumber())
+                LunarYearDestinationView(yearNumber: ChineseLunarCalendar.yearNumber())
                     .calendarDestinations()
             }
         }

--- a/Sources/ChineseCalendarUI/Home/Platform/CalendarHomeTabView.swift
+++ b/Sources/ChineseCalendarUI/Home/Platform/CalendarHomeTabView.swift
@@ -16,7 +16,7 @@ import SwiftUI
 
             TabView(selection: $router.selectedTab) {
                 NavigationStack(path: $router.yearsPath) {
-                    LunarYearDetailView(initialYearNumber: ChineseLunarCalendar.yearNumber())
+                    LunarYearDestinationView(yearNumber: ChineseLunarCalendar.yearNumber())
                         .calendarDestinations()
                 }
                 .tabItem {

--- a/Sources/ChineseCalendarUI/Tests/CalendarRouterTests.swift
+++ b/Sources/ChineseCalendarUI/Tests/CalendarRouterTests.swift
@@ -38,10 +38,10 @@ import Testing
 
 @MainActor
 @Test func browseStateTreatsYearMonthAndDayAsPageState() {
-    let browseState = LunarCalendarBrowseState(
-        displayedYearNumber: 2024,
-        selectedMonthIndex: 24001,
-        selectedDayIndex: 2_400_101
+    let browseState = LunarCalendarBrowseState(displayedYearNumber: 2024)
+    browseState.applyInitialLanding(
+        monthIndex: 24001,
+        dayIndex: 2_400_101
     )
 
     browseState.selectYear(2025)
@@ -55,10 +55,8 @@ import Testing
 @MainActor
 @Test func browseStateCanMoveAcrossYearsWithoutChangingRouter() {
     let router = CalendarRouter()
-    let browseState = LunarCalendarBrowseState(
-        displayedYearNumber: 2024,
-        selectedDayIndex: 2_400_101
-    )
+    let browseState = LunarCalendarBrowseState(displayedYearNumber: 2024)
+    browseState.applyInitialLanding(monthIndex: nil, dayIndex: 2_400_101)
 
     browseState.select(yearNumber: 2025, monthIndex: 25006)
 
@@ -71,10 +69,10 @@ import Testing
 
 @MainActor
 @Test func browseStateCanSelectAnExactDay() {
-    let browseState = LunarCalendarBrowseState(
-        displayedYearNumber: 2024,
-        selectedMonthIndex: 24001,
-        selectedDayIndex: 2_400_101
+    let browseState = LunarCalendarBrowseState(displayedYearNumber: 2024)
+    browseState.applyInitialLanding(
+        monthIndex: 24001,
+        dayIndex: 2_400_101
     )
 
     browseState.select(
@@ -119,10 +117,10 @@ import Testing
 
 @MainActor
 @Test func browseStateClearsItsDaySelectionWhenMonthChanges() {
-    let browseState = LunarCalendarBrowseState(
-        displayedYearNumber: 2026,
-        selectedMonthIndex: 26005,
-        selectedDayIndex: 2_600_501
+    let browseState = LunarCalendarBrowseState(displayedYearNumber: 2026)
+    browseState.applyInitialLanding(
+        monthIndex: 26005,
+        dayIndex: 2_600_501
     )
 
     browseState.selectedMonthIndex = 26006

--- a/Sources/ChineseCalendarUI/Tests/LunarYearDestinationViewTests.swift
+++ b/Sources/ChineseCalendarUI/Tests/LunarYearDestinationViewTests.swift
@@ -1,0 +1,59 @@
+@testable import ChineseCalendarUI
+import Testing
+
+@MainActor
+@Test func ordinaryYearEntryStartsWithoutMonthOrDayLanding() {
+    let browseState = LunarCalendarBrowseState(displayedYearNumber: 2026)
+
+    browseState.applyInitialLanding(monthIndex: nil, dayIndex: nil)
+
+    #expect(browseState.displayedYearNumber == 2026)
+    #expect(browseState.selectedMonthIndex == nil)
+    #expect(browseState.daySelection.dayIndex == nil)
+}
+
+@MainActor
+@Test func monthDeepLinkAppliesItsInitialLanding() {
+    let browseState = LunarCalendarBrowseState(displayedYearNumber: 2026)
+
+    browseState.applyInitialLanding(monthIndex: 26005, dayIndex: nil)
+
+    #expect(browseState.displayedYearNumber == 2026)
+    #expect(browseState.selectedMonthIndex == 26005)
+    #expect(browseState.daySelection.dayIndex == nil)
+}
+
+@MainActor
+@Test func dayDeepLinkAppliesItsMonthAndDayLanding() {
+    let browseState = LunarCalendarBrowseState(displayedYearNumber: 2026)
+
+    browseState.applyInitialLanding(
+        monthIndex: 26005,
+        dayIndex: 2_600_512
+    )
+
+    #expect(browseState.displayedYearNumber == 2026)
+    #expect(browseState.selectedMonthIndex == 26005)
+    #expect(browseState.daySelection.dayIndex == 2_600_512)
+}
+
+@MainActor
+@Test func rebuildingDestinationDoesNotReapplyItsInitialLanding() {
+    let browseState = LunarCalendarBrowseState(displayedYearNumber: 2026)
+    browseState.applyInitialLanding(
+        monthIndex: 26005,
+        dayIndex: 2_600_512
+    )
+    browseState.select(
+        monthIndex: 26006,
+        dayIndex: 2_600_603
+    )
+
+    browseState.applyInitialLanding(
+        monthIndex: 26005,
+        dayIndex: 2_600_512
+    )
+
+    #expect(browseState.selectedMonthIndex == 26006)
+    #expect(browseState.daySelection.dayIndex == 2_600_603)
+}


### PR DESCRIPTION
## Summary

- 新增 destination adapter，由它持有年份页面的 browse state，并一次性应用 month/day deep-link 落点
- 将 LunarYearDetailView 的核心业务输入收敛为 yearNumber，显式接收页面状态，不把浏览状态放入 Router、Environment 或全局状态
- 保留月份变化清除旧日期选择、跨月跨年、年份选择器和“今天”行为
- 增加普通年份入口、月份/日期 deep link、重建不覆盖浏览状态与月份变化清除日期的测试

## Validation

- swift test --package-path Sources：94 tests passed
- swiftformat --lint Sources：0 files require formatting
- swiftlint lint --strict --config .swiftlint.yml：0 violations
- iOS Simulator build passed
- macOS arm64 build passed
- Simulator 验证 deep link、跨标签状态保留、年份选择与“今天”流程通过
- git diff --check passed

Closes #109