### PR TITLE
使用稳定工件身份避免重复生成 seed store

### DIFF
--- a/Apps/Shared/Resources/ChineseCalendarSeedStore.bundle/manifest.json
+++ b/Apps/Shared/Resources/ChineseCalendarSeedStore.bundle/manifest.json
@@ -1,5 +1,7 @@
 {
   "artifact" : "swiftdata_import",
+  "artifactVersion" : "9a74a4f445f3b549ed4bf79a9f0e1511e552b3bf15c27008a0285dc0cb149156",
+  "datasetVersion" : "83cf6bfb03abac883492e52f7e1152947233a9cc03f1614d9162413c5fa5e737",
   "dynastyArtifact" : {
     "artifact" : "dynasty_periods",
     "generatedAt" : "2026-06-28T08:56:12.613Z",
@@ -21,6 +23,8 @@
   "endDayIndex" : 884255,
   "endYear" : 2200,
   "generatedAt" : "2026-05-31T05:31:26.411Z",
+  "schemaVersion" : "1.2.0",
+  "seedRecipeVersion" : 1,
   "seedStoreBuilder" : "Scripts/BuildChineseCalendarSeedStore",
   "seedStoreContentLevel" : "base",
   "seedStoreFormatVersion" : 4,

--- a/Docs/data model/swiftdata-seed-store.md
+++ b/Docs/data model/swiftdata-seed-store.md
@@ -35,13 +35,24 @@ Installed shared store:
   manifest.json
 ```
 
-`manifest.json` is compared at launch. If the App Group copy is missing, the bundled base store is installed. If the installed copy is already a `full` store, the bundled base store never replaces it.
+At launch, the bundled and installed manifests are compared by `artifactVersion`. Provenance-only fields such as `generatedAt` do not trigger a reinstall. If the App Group copy is missing, the bundled base store is installed. If the installed copy is already a `full` store, the bundled base store never replaces it.
+
+The stable identity fields are:
+
+- `datasetVersion`: SHA-256 of the semantic JSONL inputs in stable filename order;
+- `schemaVersion`: the explicit `ChineseCalendarModelSchema` version;
+- `seedStoreFormatVersion`: the SQLite publishing format version;
+- `seedRecipeVersion`: explicitly incremented when generation rules change semantically;
+- `artifactVersion`: SHA-256 of the four values above plus `seedStoreContentLevel`.
+
+Timestamps and source-audit provenance are retained for diagnosis, but are excluded from both hashes.
 
 Remote full-store manifest:
 
 ```json
 {
-  "datasetVersion": "2026.05.30",
+  "datasetVersion": "<sha256>",
+  "artifactVersion": "<sha256>",
   "schemaVersion": "1.2.0",
   "seedStoreContentLevel": "full",
   "seedStoreFormatVersion": 4,
@@ -56,31 +67,36 @@ Configure the remote manifest URL with either the `ChineseCalendarFullSeedStoreM
 
 ## Build The Seed Store
 
-Generate the resource bundle from the JSONL import artifact:
+Generate or update the version-controlled base resource bundle from the JSONL import artifact:
 
 ```bash
-swift run -c release --package-path Scripts/BuildChineseCalendarSeedStore ChineseCalendarSeedStoreBuilder \
-  --input Data/Processed/swiftdata_import \
-  --output Apps/Shared/Resources/ChineseCalendarSeedStore.bundle \
-  --content-level base \
-  --save-interval 5000
+make seed-store
 ```
 
-Xcode targets also run this command automatically before building if `ChineseCalendar.sqlite` is missing from the resource bundle, or if the bundled store is not the expected base-store format. The builder checkpoints WAL content back into the main database, switches the seed store to DELETE journal mode, and removes SQLite sidecar files so the bundled seed store stays as a single SQLite file.
+This is the only normal entry point that writes `Apps/Shared/Resources/ChineseCalendarSeedStore.bundle`. It calculates the current identity first and skips generation when `artifactVersion` already matches. The builder checkpoints WAL content back into the main database, switches the seed store to DELETE journal mode, and removes SQLite sidecar files so the bundled seed store stays as a single SQLite file.
+
+Ordinary iOS and macOS Xcode builds run `validate_seed_store.sh`. The phase recalculates the base identity, fails with a `make seed-store` instruction when the committed artifact is stale, and writes only a DerivedData stamp when validation succeeds. It never rewrites the tracked SQLite or manifest.
 
 The processed import directory under `Data/Processed/swiftdata_import` keeps JSONL import data, a compact manifest, and a separate `dynasty_source_audit.json` for dynasty import audit details. The resource-bundle manifest is intentionally slim: it keeps only runtime install/version fields, coverage counts, and compact provenance. Dynasty and orthodox-period records are read from the SwiftData SQLite tables, not duplicated in manifests.
 
-To build a remote full store, use a separate output directory:
+To build a remote full store, calculate a full identity first and use a separate output directory:
 
 ```bash
+identity_file="$(mktemp)"
+node Scripts/BuildChineseCalendarSeedStore/seed_store_identity.mjs \
+  --input Data/Processed/swiftdata_import \
+  --content-level full \
+  --output "$identity_file"
 swift run -c release --package-path Scripts/BuildChineseCalendarSeedStore ChineseCalendarSeedStoreBuilder \
   --input Data/Processed/swiftdata_import \
   --output Data/Processed/remote_full_seed_store \
   --content-level full \
+  --identity-file "$identity_file" \
   --save-interval 5000
+rm -f "$identity_file"
 ```
 
-Publish the full `ChineseCalendar.sqlite` plus a remote manifest that includes its byte count and SHA-256 digest. The app downloads the SQLite file into a staging directory, verifies it, opens it with SwiftData once, then atomically installs it into the App Group store directory.
+Full identities additionally cover every `calendar_days/**/*.jsonl` file. Publish the full `ChineseCalendar.sqlite` plus a remote manifest that includes its `artifactVersion`, byte count, and SQLite SHA-256 digest. The app downloads the SQLite file into a staging directory, verifies it, opens it with SwiftData once, then atomically installs it into the App Group store directory.
 
 The source artifact is intentionally still kept under `Data/Processed/swiftdata_import`. The generated `.sqlite` file is an app resource, not source data.
 

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ help:
 	@echo "  make lint                  Run SwiftLint"
 	@echo "  make ci                    Run local CI checks"
 	@echo "  make build-apps            Build iOS and macOS app targets"
-	@echo "  make seed-store            Rebuild SwiftData seed store if needed"
+	@echo "  make seed-store            Build/update the versioned SwiftData seed store artifact"
 	@echo "  make validate-data-schemas Validate generated data schema artifacts"
 
 xcodeproj:

--- a/Scripts/BuildChineseCalendarSeedStore/README.md
+++ b/Scripts/BuildChineseCalendarSeedStore/README.md
@@ -6,27 +6,40 @@
 
 ## 运行
 
-从仓库根目录执行：
+生成或更新随 App 发布的 base store 时，从仓库根目录执行唯一的写入入口：
 
 ```bash
+make seed-store
+```
+
+脚本先计算稳定的内容身份；已提交 manifest 的 `artifactVersion` 一致时直接退出，不以 mtime 判断。需要直接调用底层 builder（例如生成 full store）时，必须先生成 identity 文件：
+
+```bash
+identity_file="$(mktemp)"
+node Scripts/BuildChineseCalendarSeedStore/seed_store_identity.mjs \
+  --input Data/Processed/swiftdata_import \
+  --content-level full \
+  --output "$identity_file"
 swift run -c release --package-path Scripts/BuildChineseCalendarSeedStore ChineseCalendarSeedStoreBuilder \
   --input Data/Processed/swiftdata_import \
-  --output Apps/Shared/Resources/ChineseCalendarSeedStore.bundle \
-  --content-level base \
+  --output Data/Processed/remote_full_seed_store \
+  --content-level full \
+  --identity-file "$identity_file" \
   --save-interval 5000
+rm -f "$identity_file"
 ```
 
-默认参数等价于：
+普通 Xcode build 只运行 `validate_seed_store.sh`。它会校验 committed artifact，stale 时提示执行 `make seed-store`，成功时只更新 DerivedData stamp，不写仓库中的 SQLite 或 manifest。
 
-```bash
-swift run --package-path Scripts/BuildChineseCalendarSeedStore ChineseCalendarSeedStoreBuilder \
-  --input ../../Data/Processed/swiftdata_import \
-  --output ../../Apps/Shared/Resources/ChineseCalendarSeedStore.bundle \
-  --content-level base \
-  --save-interval 2000
-```
+## 工件身份
 
-注意默认路径是相对脚本包目录设计的；从仓库根目录运行时建议显式传 `--input` 和 `--output`。
+- `datasetVersion`：按稳定文件名顺序覆盖实际导入 JSONL 的 SHA-256；
+- `schemaVersion`：`ChineseCalendarModelSchema.versionIdentifier`；
+- `seedStoreFormatVersion`：发布格式版本；
+- `seedRecipeVersion`：生成规则语义变化时显式递增；
+- `artifactVersion`：上述字段与 `seedStoreContentLevel` 的组合 SHA-256。
+
+`generatedAt`、`rawFetchedAt` 等 provenance 不参与身份计算。base identity 覆盖 builder 实际读取的全部十个 JSONL；full identity 还覆盖 `calendar_days` 下全部日级 JSONL。
 
 ## 参数
 
@@ -34,6 +47,7 @@ swift run --package-path Scripts/BuildChineseCalendarSeedStore ChineseCalendarSe
 --input <path>          SwiftData import JSONL 目录
 --output <path>         输出的 resource bundle 目录
 --content-level <level> 输出内容级别：base 或 full，默认 base
+--identity-file <path>  seed_store_identity.mjs 生成的身份文件，必填
 --keep-output           不删除整个 output 目录，只清理旧 SQLite store 文件
 --save-interval <count> 每导入多少条日数据保存一次，必须为正整数
 --help                  打印帮助
@@ -59,6 +73,9 @@ Data/Processed/swiftdata_import/
   chinese_lunar_months.jsonl
   chinese_date_expressions.jsonl
   dynasties.jsonl
+  emperors.jsonl
+  emperor_reign_segments.jsonl
+  reign_eras.jsonl
   dynasty_source_audit.json
   orthodox_traditions.jsonl
   orthodox_boundaries.jsonl
@@ -74,9 +91,12 @@ Data/Processed/swiftdata_import/
 3. `CalendarDay` + `CivilDate` + `ChineseLunarDay`
 4. `ChineseDateExpression`
 5. `Dynasty`
-6. `OrthodoxTradition`
-7. `OrthodoxBoundary`
-8. `OrthodoxPeriod`
+6. `Emperor`
+7. `EmperorReignSegment`
+8. `ReignEra`
+9. `OrthodoxTradition`
+10. `OrthodoxBoundary`
+11. `OrthodoxPeriod`
 
 `full` 模式下，日数据按 civil year 分目录读取，并按目录名数字升序导入。`base` 模式会跳过第 3 步，但仍会导入农历年、农历月、朝代和正统时期数据。
 

--- a/Scripts/BuildChineseCalendarSeedStore/Sources/ChineseCalendarSeedStoreBuilder/main.swift
+++ b/Scripts/BuildChineseCalendarSeedStore/Sources/ChineseCalendarSeedStoreBuilder/main.swift
@@ -15,6 +15,7 @@ private struct SeedStoreBuilderOptions {
     let inputURL: URL
     let outputURL: URL
     let contentLevel: SeedStoreContentLevel
+    let identityFileURL: URL
     let resetOutput: Bool
     let saveInterval: Int
 
@@ -22,6 +23,7 @@ private struct SeedStoreBuilderOptions {
         var inputPath = "../../Data/Processed/swiftdata_import"
         var outputPath = "../../Apps/Shared/Resources/ChineseCalendarSeedStore.bundle"
         var contentLevel = SeedStoreContentLevel.base
+        var identityFilePath: String?
         var resetOutput = true
         var saveInterval = 2000
 
@@ -39,6 +41,8 @@ private struct SeedStoreBuilderOptions {
                     throw SeedStoreBuilderError.invalidArgument("--content-level must be base or full.")
                 }
                 contentLevel = parsedLevel
+            case "--identity-file":
+                identityFilePath = try Self.value(after: argument, in: arguments, at: &index)
             case "--keep-output":
                 resetOutput = false
             case "--save-interval":
@@ -59,6 +63,12 @@ private struct SeedStoreBuilderOptions {
 
         inputURL = URL(fileURLWithPath: inputPath).standardizedFileURL
         outputURL = URL(fileURLWithPath: outputPath).standardizedFileURL
+        guard let identityFilePath else {
+            throw SeedStoreBuilderError.invalidArgument(
+                "--identity-file is required. Generate it with seed_store_identity.mjs."
+            )
+        }
+        identityFileURL = URL(fileURLWithPath: identityFilePath).standardizedFileURL
         self.contentLevel = contentLevel
         self.resetOutput = resetOutput
         self.saveInterval = saveInterval
@@ -85,20 +95,28 @@ private struct SeedStoreBuilderOptions {
       --input <path>          SwiftData import JSONL directory. Default: ../../Data/Processed/swiftdata_import
       --output <path>         Output resource bundle directory. Default: ../../Apps/Shared/Resources/ChineseCalendarSeedStore.bundle
       --content-level <level> Store content to build: base or full. Default: base
+      --identity-file <path>  Calculated dataset and artifact identity JSON. Required
       --keep-output           Do not delete the existing output directory before building.
       --save-interval <count> Save after this many day bundles. Default: 2000
       --help                  Show this help text.
     """
 }
 
-private enum SeedStoreContentLevel: String {
+private enum SeedStoreContentLevel: String, Decodable {
     case base
     case full
 }
 
-private struct SeedStoreBuilder {
-    private static let seedStoreFormatVersion = 4
+private struct SeedStoreArtifactIdentity: Decodable {
+    let datasetVersion: String
+    let schemaVersion: String
+    let seedStoreFormatVersion: Int
+    let seedStoreContentLevel: SeedStoreContentLevel
+    let seedRecipeVersion: Int
+    let artifactVersion: String
+}
 
+private struct SeedStoreBuilder {
     private let options: SeedStoreBuilderOptions
     private let decoder = JSONDecoder()
     private let fileManager = FileManager.default
@@ -108,6 +126,8 @@ private struct SeedStoreBuilder {
     }
 
     func build() throws {
+        let identity = try loadIdentity()
+
         if options.resetOutput {
             try? fileManager.removeItem(at: options.outputURL)
         }
@@ -138,8 +158,28 @@ private struct SeedStoreBuilder {
         }
 
         try finalizeSQLiteStore(at: storeURL)
-        try copyManifest()
+        try copyManifest(identity: identity)
         log("Seed store written to \(options.outputURL.path)")
+    }
+
+    private func loadIdentity() throws -> SeedStoreArtifactIdentity {
+        let data = try Data(contentsOf: options.identityFileURL)
+        let identity = try decoder.decode(SeedStoreArtifactIdentity.self, from: data)
+
+        guard identity.seedStoreContentLevel == options.contentLevel else {
+            throw SeedStoreBuilderError.identityContentLevelMismatch(
+                identity.seedStoreContentLevel.rawValue,
+                expected: options.contentLevel.rawValue
+            )
+        }
+        guard identity.schemaVersion == ChineseCalendarModelSchema.versionIdentifier else {
+            throw SeedStoreBuilderError.identitySchemaVersionMismatch(
+                identity.schemaVersion,
+                expected: ChineseCalendarModelSchema.versionIdentifier
+            )
+        }
+
+        return identity
     }
 
     private func importLunarYears(into container: ModelContainer) throws {
@@ -615,7 +655,7 @@ private struct SeedStoreBuilder {
         }
     }
 
-    private func copyManifest() throws {
+    private func copyManifest(identity: SeedStoreArtifactIdentity) throws {
         let sourceURL = options.inputURL.appendingPathComponent(ChineseCalendarSeedStore.manifestFileName)
         let destinationURL = options.outputURL.appendingPathComponent(ChineseCalendarSeedStore.manifestFileName)
 
@@ -629,9 +669,13 @@ private struct SeedStoreBuilder {
         }
 
         var runtimeManifest = runtimeSeedStoreManifest(from: manifest)
+        runtimeManifest["datasetVersion"] = identity.datasetVersion
+        runtimeManifest["schemaVersion"] = identity.schemaVersion
+        runtimeManifest["seedStoreFormatVersion"] = identity.seedStoreFormatVersion
+        runtimeManifest["seedRecipeVersion"] = identity.seedRecipeVersion
+        runtimeManifest["artifactVersion"] = identity.artifactVersion
         runtimeManifest["seedStoreBuilder"] = "Scripts/BuildChineseCalendarSeedStore"
         runtimeManifest["seedStoreContentLevel"] = options.contentLevel.rawValue
-        runtimeManifest["seedStoreFormatVersion"] = Self.seedStoreFormatVersion
         runtimeManifest["seedStoreHistoryPurged"] = true
         runtimeManifest["seedStoreRelationshipsLinked"] = true
 
@@ -757,6 +801,8 @@ private enum SeedStoreBuilderError: Error, LocalizedError {
     case missingReference(String)
     case unusedDateExpressions(String)
     case duplicateRecord(String, String)
+    case identityContentLevelMismatch(String, expected: String)
+    case identitySchemaVersionMismatch(String, expected: String)
 
     var errorDescription: String? {
         switch self {
@@ -776,6 +822,10 @@ private enum SeedStoreBuilderError: Error, LocalizedError {
             "Unused ChineseDateExpression records: \(ids)."
         case let .duplicateRecord(entity, id):
             "Duplicate \(entity) record id: \(id)."
+        case let .identityContentLevelMismatch(contentLevel, expected):
+            "Seed store identity content level \(contentLevel) does not match requested level \(expected)."
+        case let .identitySchemaVersionMismatch(version, expected):
+            "Seed store identity schema version \(version) does not match model schema version \(expected)."
         }
     }
 }

--- a/Scripts/BuildChineseCalendarSeedStore/Tests/seed_store_identity.test.mjs
+++ b/Scripts/BuildChineseCalendarSeedStore/Tests/seed_store_identity.test.mjs
@@ -1,0 +1,110 @@
+import assert from "node:assert/strict";
+import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import {
+  BASE_INPUT_FILES,
+  calculateSeedStoreIdentity,
+  validateSeedStoreManifest
+} from "../seed_store_identity.mjs";
+
+test("dataset identity is stable across provenance changes and changes with semantic input", async () => {
+  const fixture = await makeFixture();
+  try {
+    const first = await calculateBaseIdentity(fixture);
+    await writeFile(path.join(fixture.root, "manifest.json"), '{"generatedAt":"later"}\n', "utf8");
+    const provenanceOnly = await calculateBaseIdentity(fixture);
+    assert.deepEqual(provenanceOnly, first);
+
+    await writeFile(path.join(fixture.root, BASE_INPUT_FILES[0]), "changed\n", "utf8");
+    const semanticChange = await calculateBaseIdentity(fixture);
+    assert.notEqual(semanticChange.datasetVersion, first.datasetVersion);
+    assert.notEqual(semanticChange.artifactVersion, first.artifactVersion);
+  } finally {
+    await fixture.remove();
+  }
+});
+
+test("artifact identity changes with schema, format, content level, and recipe", async () => {
+  const fixture = await makeFixture();
+  try {
+    const base = await calculateBaseIdentity(fixture);
+
+    await writeFile(fixture.schemaSource, schemaSource("1.3.0"), "utf8");
+    const schemaChange = await calculateBaseIdentity(fixture);
+    assert.notEqual(schemaChange.artifactVersion, base.artifactVersion);
+
+    await writeFile(fixture.schemaSource, schemaSource("1.2.0"), "utf8");
+    const formatChange = await calculateBaseIdentity(fixture, { seedStoreFormatVersion: 5 });
+    const recipeChange = await calculateBaseIdentity(fixture, { seedRecipeVersion: 2 });
+    assert.notEqual(formatChange.artifactVersion, base.artifactVersion);
+    assert.notEqual(recipeChange.artifactVersion, base.artifactVersion);
+
+    const dayDirectory = path.join(fixture.root, "calendar_days/2000");
+    await mkdir(dayDirectory, { recursive: true });
+    await writeFile(path.join(dayDirectory, "calendar_days.jsonl"), "day\n", "utf8");
+    const full = await calculateSeedStoreIdentity({
+      inputDirectory: fixture.root,
+      schemaSource: fixture.schemaSource,
+      contentLevel: "full"
+    });
+    assert.notEqual(full.artifactVersion, base.artifactVersion);
+  } finally {
+    await fixture.remove();
+  }
+});
+
+test("manifest validation ignores provenance but rejects a stale artifact", async () => {
+  const fixture = await makeFixture();
+  try {
+    const identity = await calculateBaseIdentity(fixture);
+    const manifestPath = path.join(fixture.root, "bundled-manifest.json");
+    await writeFile(
+      manifestPath,
+      `${JSON.stringify({ ...identity, generatedAt: "provenance-only" })}\n`,
+      "utf8"
+    );
+    await validateSeedStoreManifest(identity, manifestPath);
+
+    await writeFile(
+      manifestPath,
+      `${JSON.stringify({ ...identity, artifactVersion: "stale" })}\n`,
+      "utf8"
+    );
+    await assert.rejects(
+      validateSeedStoreManifest(identity, manifestPath),
+      /Run `make seed-store`/
+    );
+  } finally {
+    await fixture.remove();
+  }
+});
+
+async function makeFixture() {
+  const root = await mkdtemp(path.join(os.tmpdir(), "seed-store-identity-"));
+  const schemaSourcePath = path.join(root, "PersistenceSupport.swift");
+  await writeFile(schemaSourcePath, schemaSource("1.2.0"), "utf8");
+  await Promise.all(
+    BASE_INPUT_FILES.map((file, index) => writeFile(path.join(root, file), `record-${index}\n`, "utf8"))
+  );
+  return {
+    root,
+    schemaSource: schemaSourcePath,
+    remove: () => rm(root, { recursive: true, force: true })
+  };
+}
+
+function calculateBaseIdentity(fixture, overrides = {}) {
+  return calculateSeedStoreIdentity({
+    inputDirectory: fixture.root,
+    schemaSource: fixture.schemaSource,
+    contentLevel: "base",
+    ...overrides
+  });
+}
+
+function schemaSource(version) {
+  return `public enum ChineseCalendarModelSchema {\n    public static let versionIdentifier = "${version}"\n}\n`;
+}

--- a/Scripts/BuildChineseCalendarSeedStore/generate_seed_store_if_needed.sh
+++ b/Scripts/BuildChineseCalendarSeedStore/generate_seed_store_if_needed.sh
@@ -8,7 +8,6 @@ INPUT_DIR="$REPO_ROOT/Data/Processed/swiftdata_import"
 OUTPUT_DIR="$REPO_ROOT/Apps/Shared/Resources/ChineseCalendarSeedStore.bundle"
 SEED_STORE="$OUTPUT_DIR/ChineseCalendar.sqlite"
 SEED_MANIFEST="$OUTPUT_DIR/manifest.json"
-REQUIRED_SEED_STORE_FORMAT_VERSION="4"
 REQUIRED_SEED_STORE_CONTENT_LEVEL="base"
 
 if [[ "${CHINESE_CALENDAR_SKIP_SEED_STORE_BUILD:-}" == "1" ]]; then
@@ -16,45 +15,29 @@ if [[ "${CHINESE_CALENDAR_SKIP_SEED_STORE_BUILD:-}" == "1" ]]; then
     exit 0
 fi
 
-seed_store_format_version() {
-    if [[ ! -f "$SEED_MANIFEST" ]]; then
-        return 1
-    fi
-
-    plutil -extract seedStoreFormatVersion raw "$SEED_MANIFEST" 2>/dev/null
-}
-
-seed_store_content_level() {
-    if [[ ! -f "$SEED_MANIFEST" ]]; then
-        return 1
-    fi
-
-    plutil -extract seedStoreContentLevel raw "$SEED_MANIFEST" 2>/dev/null
-}
-
-source_data_is_newer_than_seed_manifest() {
-    [[ "$INPUT_DIR/manifest.json" -nt "$SEED_MANIFEST" ]] && return 0
-    [[ -n "$(find "$INPUT_DIR" -name '*.jsonl' -newer "$SEED_MANIFEST" -print -quit)" ]]
-}
-
 if [[ -f "$SEED_STORE" && -f "$SEED_MANIFEST" ]]; then
-    current_format_version="$(seed_store_format_version || true)"
-    current_content_level="$(seed_store_content_level || true)"
-    if [[ "$current_format_version" == "$REQUIRED_SEED_STORE_FORMAT_VERSION" ]] && \
-        [[ "$current_content_level" == "$REQUIRED_SEED_STORE_CONTENT_LEVEL" ]] && \
-        ! source_data_is_newer_than_seed_manifest; then
-        if [[ -f "$SEED_STORE-wal" || -f "$SEED_STORE-shm" ]]; then
-            sqlite3 "$SEED_STORE" 'PRAGMA wal_checkpoint(TRUNCATE); PRAGMA journal_mode=DELETE;'
-            rm -f "$SEED_STORE-shm" "$SEED_STORE-wal"
-        fi
-
+    if node "$SCRIPT_DIR/seed_store_identity.mjs" \
+        --input "$INPUT_DIR" \
+        --content-level "$REQUIRED_SEED_STORE_CONTENT_LEVEL" \
+        --check-manifest "$SEED_MANIFEST" >/dev/null 2>&1; then
+        echo "SwiftData seed store already matches the current artifact identity."
         exit 0
     fi
 fi
+
+IDENTITY_DIRECTORY="$(mktemp -d)"
+trap 'rm -rf "$IDENTITY_DIRECTORY"' EXIT
+IDENTITY_FILE="$IDENTITY_DIRECTORY/identity.json"
+
+node "$SCRIPT_DIR/seed_store_identity.mjs" \
+    --input "$INPUT_DIR" \
+    --content-level "$REQUIRED_SEED_STORE_CONTENT_LEVEL" \
+    --output "$IDENTITY_FILE"
 
 env -u SDKROOT -u TOOLCHAINS swift run -c release --package-path "$REPO_ROOT/Scripts/BuildChineseCalendarSeedStore" ChineseCalendarSeedStoreBuilder \
     --input "$INPUT_DIR" \
     --output "$OUTPUT_DIR" \
     --content-level "$REQUIRED_SEED_STORE_CONTENT_LEVEL" \
+    --identity-file "$IDENTITY_FILE" \
     --keep-output \
     --save-interval 5000

--- a/Scripts/BuildChineseCalendarSeedStore/seed_store_identity.mjs
+++ b/Scripts/BuildChineseCalendarSeedStore/seed_store_identity.mjs
@@ -1,0 +1,233 @@
+#!/usr/bin/env node
+
+import { createHash } from "node:crypto";
+import { readFile, readdir, writeFile } from "node:fs/promises";
+import path from "node:path";
+import process from "node:process";
+import { fileURLToPath } from "node:url";
+
+export const SEED_STORE_FORMAT_VERSION = 4;
+export const SEED_RECIPE_VERSION = 1;
+
+export const BASE_INPUT_FILES = Object.freeze([
+  "chinese_lunar_years.jsonl",
+  "chinese_lunar_months.jsonl",
+  "chinese_date_expressions.jsonl",
+  "dynasties.jsonl",
+  "emperors.jsonl",
+  "emperor_reign_segments.jsonl",
+  "reign_eras.jsonl",
+  "orthodox_traditions.jsonl",
+  "orthodox_boundaries.jsonl",
+  "orthodox_periods.jsonl"
+]);
+
+const scriptPath = fileURLToPath(import.meta.url);
+const scriptDirectory = path.dirname(scriptPath);
+const repositoryRoot = path.resolve(scriptDirectory, "../..");
+const defaultInputDirectory = path.join(repositoryRoot, "Data/Processed/swiftdata_import");
+const defaultSchemaSource = path.join(
+  repositoryRoot,
+  "Sources/ChineseCalendarPersistence/PersistenceSupport.swift"
+);
+
+export async function calculateSeedStoreIdentity({
+  inputDirectory,
+  contentLevel,
+  schemaSource = defaultSchemaSource,
+  seedStoreFormatVersion = SEED_STORE_FORMAT_VERSION,
+  seedRecipeVersion = SEED_RECIPE_VERSION
+}) {
+  if (contentLevel !== "base" && contentLevel !== "full") {
+    throw new Error("contentLevel must be base or full.");
+  }
+
+  const schemaVersion = await readSchemaVersion(schemaSource);
+  const inputFiles = await inputFilesForContentLevel(inputDirectory, contentLevel);
+  const datasetVersion = await hashDataset(inputDirectory, inputFiles);
+  const artifactDescription = {
+    datasetVersion,
+    schemaVersion,
+    seedStoreFormatVersion,
+    seedStoreContentLevel: contentLevel,
+    seedRecipeVersion
+  };
+  const artifactVersion = sha256(JSON.stringify(artifactDescription));
+
+  return {
+    ...artifactDescription,
+    artifactVersion,
+    inputFiles
+  };
+}
+
+export async function validateSeedStoreManifest(identity, manifestPath) {
+  let manifest;
+  try {
+    manifest = JSON.parse(await readFile(manifestPath, "utf8"));
+  } catch (error) {
+    if (error.code === "ENOENT") {
+      throw new Error(`Bundled seed store manifest is missing: ${manifestPath}`);
+    }
+    throw error;
+  }
+
+  const identityKeys = [
+    "datasetVersion",
+    "schemaVersion",
+    "seedStoreFormatVersion",
+    "seedStoreContentLevel",
+    "seedRecipeVersion",
+    "artifactVersion"
+  ];
+  const mismatches = identityKeys.filter((key) => manifest[key] !== identity[key]);
+  if (mismatches.length > 0) {
+    const details = mismatches
+      .map((key) => `${key}: expected ${JSON.stringify(identity[key])}, found ${JSON.stringify(manifest[key])}`)
+      .join("; ");
+    throw new Error(`Bundled seed store is stale (${details}). Run \`make seed-store\` from the repository root.`);
+  }
+}
+
+async function readSchemaVersion(schemaSource) {
+  const source = await readFile(schemaSource, "utf8");
+  const match = source.match(/public static let versionIdentifier = "([^"]+)"/);
+  if (!match) {
+    throw new Error(`Unable to read ChineseCalendarModelSchema.versionIdentifier from ${schemaSource}.`);
+  }
+  return match[1];
+}
+
+async function inputFilesForContentLevel(inputDirectory, contentLevel) {
+  const inputFiles = [...BASE_INPUT_FILES];
+  if (contentLevel === "full") {
+    const calendarDaysDirectory = path.join(inputDirectory, "calendar_days");
+    const dayFiles = await collectJSONLFiles(calendarDaysDirectory, "calendar_days");
+    inputFiles.push(...dayFiles);
+  }
+  return inputFiles.sort();
+}
+
+async function collectJSONLFiles(directory, relativeDirectory) {
+  const entries = await readdir(directory, { withFileTypes: true });
+  const files = [];
+  for (const entry of entries) {
+    const relativePath = path.posix.join(relativeDirectory, entry.name);
+    const absolutePath = path.join(directory, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...(await collectJSONLFiles(absolutePath, relativePath)));
+    } else if (entry.isFile() && entry.name.endsWith(".jsonl")) {
+      files.push(relativePath);
+    }
+  }
+  return files.sort();
+}
+
+async function hashDataset(inputDirectory, inputFiles) {
+  const hash = createHash("sha256");
+  hash.update("ChineseCalendarSeedStoreDataset-v1\0", "utf8");
+
+  for (const relativePath of inputFiles) {
+    const data = await readFile(path.join(inputDirectory, relativePath));
+    hash.update(relativePath, "utf8");
+    hash.update("\0", "utf8");
+    hash.update(String(data.byteLength), "utf8");
+    hash.update("\0", "utf8");
+    hash.update(data);
+    hash.update("\0", "utf8");
+  }
+
+  return hash.digest("hex");
+}
+
+function sha256(value) {
+  return createHash("sha256").update(value, "utf8").digest("hex");
+}
+
+async function parseArguments(argumentsList) {
+  const options = {
+    inputDirectory: defaultInputDirectory,
+    schemaSource: defaultSchemaSource,
+    contentLevel: "base",
+    checkManifest: undefined,
+    output: undefined,
+    help: false
+  };
+
+  for (let index = 0; index < argumentsList.length; index += 1) {
+    const argument = argumentsList[index];
+    switch (argument) {
+      case "--input":
+        options.inputDirectory = path.resolve(requireOptionValue(argument, argumentsList[++index]));
+        break;
+      case "--schema-source":
+        options.schemaSource = path.resolve(requireOptionValue(argument, argumentsList[++index]));
+        break;
+      case "--content-level":
+        options.contentLevel = requireOptionValue(argument, argumentsList[++index]);
+        break;
+      case "--check-manifest":
+        options.checkManifest = path.resolve(requireOptionValue(argument, argumentsList[++index]));
+        break;
+      case "--output":
+        options.output = path.resolve(requireOptionValue(argument, argumentsList[++index]));
+        break;
+      case "--help":
+      case "-h":
+        options.help = true;
+        break;
+      default:
+        throw new Error(`Unknown argument: ${argument}`);
+    }
+  }
+
+  return options;
+}
+
+function requireOptionValue(name, value) {
+  if (value === undefined || value.startsWith("--")) {
+    throw new Error(`${name} requires a value.`);
+  }
+  return value;
+}
+
+function printHelp() {
+  console.log(`Usage:
+  node seed_store_identity.mjs [options]
+
+Options:
+  --input <path>            SwiftData import JSONL directory.
+  --schema-source <path>    Swift source containing the model schema version identifier.
+  --content-level <level>   Identity content level: base or full. Default: base
+  --check-manifest <path>   Fail unless the manifest contains the calculated identity.
+  --output <path>           Write the calculated identity JSON to this file.
+  --help                    Show this help text.
+`);
+}
+
+async function main() {
+  const options = await parseArguments(process.argv.slice(2));
+  if (options.help) {
+    printHelp();
+    return;
+  }
+
+  const identity = await calculateSeedStoreIdentity(options);
+  if (options.checkManifest) {
+    await validateSeedStoreManifest(identity, options.checkManifest);
+  }
+
+  const output = `${JSON.stringify(identity, null, 2)}\n`;
+  if (options.output) {
+    await writeFile(options.output, output, "utf8");
+  } else if (!options.checkManifest) {
+    process.stdout.write(output);
+  }
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === scriptPath) {
+  main().catch((error) => {
+    console.error(error.message);
+    process.exitCode = 1;
+  });
+}

--- a/Scripts/BuildChineseCalendarSeedStore/validate_seed_store.sh
+++ b/Scripts/BuildChineseCalendarSeedStore/validate_seed_store.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="${SRCROOT:-$(cd "$SCRIPT_DIR/../.." && pwd)}"
+INPUT_DIR="$REPO_ROOT/Data/Processed/swiftdata_import"
+OUTPUT_DIR="$REPO_ROOT/Apps/Shared/Resources/ChineseCalendarSeedStore.bundle"
+SEED_STORE="$OUTPUT_DIR/ChineseCalendar.sqlite"
+SEED_MANIFEST="$OUTPUT_DIR/manifest.json"
+STAMP_FILE="${1:-}"
+
+if [[ "${CHINESE_CALENDAR_SKIP_SEED_STORE_BUILD:-}" == "1" ]]; then
+    echo "Skipping SwiftData seed store validation because CHINESE_CALENDAR_SKIP_SEED_STORE_BUILD=1."
+else
+    if [[ ! -f "$SEED_STORE" ]]; then
+        echo "Bundled seed store is missing: $SEED_STORE" >&2
+        echo "Run 'make seed-store' from the repository root." >&2
+        exit 1
+    fi
+
+    node "$SCRIPT_DIR/seed_store_identity.mjs" \
+        --input "$INPUT_DIR" \
+        --content-level base \
+        --check-manifest "$SEED_MANIFEST"
+fi
+
+if [[ -n "$STAMP_FILE" ]]; then
+    mkdir -p "$(dirname "$STAMP_FILE")"
+    touch "$STAMP_FILE"
+fi

--- a/Scripts/test.sh
+++ b/Scripts/test.sh
@@ -2,4 +2,5 @@
 
 set -euo pipefail
 
+node --test Scripts/BuildChineseCalendarSeedStore/Tests/*.test.mjs
 swift test --package-path Sources

--- a/Sources/ChineseCalendarPersistence/ChineseCalendarFullSeedStoreInstaller.swift
+++ b/Sources/ChineseCalendarPersistence/ChineseCalendarFullSeedStoreInstaller.swift
@@ -5,6 +5,7 @@ import SwiftData
 
 public struct FullSeedStoreManifest: Decodable, Sendable {
     public let datasetVersion: String
+    public let artifactVersion: String?
     public let schemaVersion: String
     public let seedStoreContentLevel: ChineseCalendarSeedStoreContentLevel
     public let seedStoreFormatVersion: Int
@@ -15,6 +16,7 @@ public struct FullSeedStoreManifest: Decodable, Sendable {
 
     public init(
         datasetVersion: String,
+        artifactVersion: String? = nil,
         schemaVersion: String,
         seedStoreContentLevel: ChineseCalendarSeedStoreContentLevel,
         seedStoreFormatVersion: Int,
@@ -24,6 +26,7 @@ public struct FullSeedStoreManifest: Decodable, Sendable {
         downloadURL: URL
     ) {
         self.datasetVersion = datasetVersion
+        self.artifactVersion = artifactVersion
         self.schemaVersion = schemaVersion
         self.seedStoreContentLevel = seedStoreContentLevel
         self.seedStoreFormatVersion = seedStoreFormatVersion
@@ -79,7 +82,7 @@ public enum ChineseCalendarFullSeedStoreInstallError: Error, LocalizedError {
 }
 
 public actor ChineseCalendarFullSeedStoreInstaller {
-    private static let supportedSchemaVersion = "1.2.0"
+    private static let supportedSchemaVersion = ChineseCalendarModelSchema.versionIdentifier
 
     private let configuration: FullSeedStoreConfig
     private let appGroupIdentifier: String
@@ -387,7 +390,7 @@ private extension ChineseCalendarFullSeedStoreInstaller {
         to storeDirectory: URL
     ) throws {
         let manifestURL = storeDirectory.appendingPathComponent(ChineseCalendarSeedStore.manifestFileName)
-        let data: [String: Any] = [
+        var data: [String: Any] = [
             "datasetVersion": manifest.datasetVersion,
             "schemaVersion": manifest.schemaVersion,
             "seedStoreContentLevel": manifest.seedStoreContentLevel.rawValue,
@@ -398,6 +401,9 @@ private extension ChineseCalendarFullSeedStoreInstaller {
             "downloadURL": manifest.downloadURL.absoluteString,
             "installedAt": ISO8601DateFormatter().string(from: Date())
         ]
+        if let artifactVersion = manifest.artifactVersion {
+            data["artifactVersion"] = artifactVersion
+        }
         var encodedData = try JSONSerialization.data(
             withJSONObject: data,
             options: [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]

--- a/Sources/ChineseCalendarPersistence/PersistenceSupport.swift
+++ b/Sources/ChineseCalendarPersistence/PersistenceSupport.swift
@@ -7,6 +7,7 @@ public enum CivilCalendarStyle: String, Codable, CaseIterable, Sendable {
 }
 
 public enum ChineseCalendarModelSchema {
+    public static let versionIdentifier = "1.2.0"
     public static let version = Schema.Version(1, 2, 0)
 
     public static let models: [any PersistentModel.Type] = [

--- a/Sources/ChineseCalendarPersistence/SeededModelContainer.swift
+++ b/Sources/ChineseCalendarPersistence/SeededModelContainer.swift
@@ -177,12 +177,7 @@ public enum ChineseCalendarModelContainerFactory {
             return nil
         }
 
-        let data = try Data(contentsOf: manifestURL)
-        guard let manifest = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
-            return nil
-        }
-
-        return manifest["datasetVersion"] as? String ?? manifest["generatedAt"] as? String
+        return try seedStoreIdentityToken(at: manifestURL)
     }
 
     private static func installSeedStoreIfNeeded(
@@ -235,7 +230,7 @@ public enum ChineseCalendarModelContainerFactory {
         return storeURL
     }
 
-    private static func shouldInstallSeedStore(
+    static func shouldInstallSeedStore(
         seedDirectory: URL,
         storeDirectory: URL,
         fileManager: FileManager
@@ -263,7 +258,31 @@ public enum ChineseCalendarModelContainerFactory {
             return false
         }
 
-        return try Data(contentsOf: seedManifestURL) != Data(contentsOf: installedManifestURL)
+        guard let seedArtifactVersion = try seedStoreArtifactVersion(at: seedManifestURL) else {
+            ChineseCalendarLog.persistence.error(
+                "Bundled seed store manifest has no artifactVersion; keeping the installed store"
+            )
+            return false
+        }
+
+        return try seedStoreArtifactVersion(at: installedManifestURL) != seedArtifactVersion
+    }
+
+    static func seedStoreIdentityToken(at manifestURL: URL) throws -> String? {
+        let manifest = try seedStoreManifest(at: manifestURL)
+        return manifest["artifactVersion"] as? String ?? manifest["datasetVersion"] as? String
+    }
+
+    private static func seedStoreArtifactVersion(at manifestURL: URL) throws -> String? {
+        try seedStoreManifest(at: manifestURL)["artifactVersion"] as? String
+    }
+
+    private static func seedStoreManifest(at manifestURL: URL) throws -> [String: Any] {
+        let data = try Data(contentsOf: manifestURL)
+        guard let manifest = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            return [:]
+        }
+        return manifest
     }
 
     private static func seedStoreContentLevel(at manifestURL: URL) throws -> ChineseCalendarSeedStoreContentLevel? {

--- a/Sources/ChineseCalendarPersistence/Tests/SeededModelContainerTests.swift
+++ b/Sources/ChineseCalendarPersistence/Tests/SeededModelContainerTests.swift
@@ -1,0 +1,120 @@
+@testable import ChineseCalendarPersistence
+import Foundation
+import Testing
+
+@Suite("Seed store artifact identity")
+struct SeededModelContainerTests {
+    @Test func provenanceOnlyManifestChangesDoNotReinstall() throws {
+        let fixture = try SeedStoreFixture(
+            seedManifest: Self.manifest(artifactVersion: "artifact-a", generatedAt: "new"),
+            installedManifest: Self.manifest(artifactVersion: "artifact-a", generatedAt: "old")
+        )
+        defer { fixture.remove() }
+
+        #expect(try !fixture.shouldInstall())
+    }
+
+    @Test func changedArtifactVersionReinstallsBundledBaseStore() throws {
+        let fixture = try SeedStoreFixture(
+            seedManifest: Self.manifest(artifactVersion: "artifact-b"),
+            installedManifest: Self.manifest(artifactVersion: "artifact-a")
+        )
+        defer { fixture.remove() }
+
+        #expect(try fixture.shouldInstall())
+    }
+
+    @Test func installedFullStoreIsNeverReplacedByBundledBaseStore() throws {
+        let fixture = try SeedStoreFixture(
+            seedManifest: Self.manifest(artifactVersion: "artifact-b", contentLevel: "base"),
+            installedManifest: Self.manifest(artifactVersion: "artifact-a", contentLevel: "full")
+        )
+        defer { fixture.remove() }
+
+        #expect(try !fixture.shouldInstall())
+    }
+
+    @Test func missingInstalledManifestRequiresInstallation() throws {
+        let fixture = try SeedStoreFixture(
+            seedManifest: Self.manifest(artifactVersion: "artifact-a"),
+            installedManifest: nil
+        )
+        defer { fixture.remove() }
+
+        #expect(try fixture.shouldInstall())
+    }
+
+    @Test func identityTokenPrefersArtifactThenDatasetAndNeverUsesGeneratedAt() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("SeedStoreIdentityTests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let manifestURL = directory.appendingPathComponent("manifest.json")
+
+        try writeJSON(
+            ["artifactVersion": "artifact-a", "datasetVersion": "dataset-a", "generatedAt": "timestamp"],
+            to: manifestURL
+        )
+        #expect(try ChineseCalendarModelContainerFactory.seedStoreIdentityToken(at: manifestURL) == "artifact-a")
+
+        try writeJSON(["datasetVersion": "dataset-a", "generatedAt": "timestamp"], to: manifestURL)
+        #expect(try ChineseCalendarModelContainerFactory.seedStoreIdentityToken(at: manifestURL) == "dataset-a")
+
+        try writeJSON(["generatedAt": "timestamp"], to: manifestURL)
+        #expect(try ChineseCalendarModelContainerFactory.seedStoreIdentityToken(at: manifestURL) == nil)
+    }
+
+    private static func manifest(
+        artifactVersion: String,
+        generatedAt: String = "timestamp",
+        contentLevel: String = "base"
+    ) -> [String: Any] {
+        [
+            "artifactVersion": artifactVersion,
+            "datasetVersion": "dataset",
+            "generatedAt": generatedAt,
+            "seedStoreContentLevel": contentLevel
+        ]
+    }
+}
+
+private struct SeedStoreFixture {
+    let rootURL: URL
+    let seedDirectory: URL
+    let storeDirectory: URL
+
+    init(seedManifest: [String: Any], installedManifest: [String: Any]?) throws {
+        rootURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("SeedStoreTests-\(UUID().uuidString)", isDirectory: true)
+        seedDirectory = rootURL.appendingPathComponent("seed", isDirectory: true)
+        storeDirectory = rootURL.appendingPathComponent("installed", isDirectory: true)
+        try FileManager.default.createDirectory(at: seedDirectory, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: storeDirectory, withIntermediateDirectories: true)
+
+        try Data().write(to: storeDirectory.appendingPathComponent(ChineseCalendarSeedStore.storeFileName))
+        try writeJSON(seedManifest, to: seedDirectory.appendingPathComponent(ChineseCalendarSeedStore.manifestFileName))
+        if let installedManifest {
+            try writeJSON(
+                installedManifest,
+                to: storeDirectory.appendingPathComponent(ChineseCalendarSeedStore.manifestFileName)
+            )
+        }
+    }
+
+    func shouldInstall() throws -> Bool {
+        try ChineseCalendarModelContainerFactory.shouldInstallSeedStore(
+            seedDirectory: seedDirectory,
+            storeDirectory: storeDirectory,
+            fileManager: .default
+        )
+    }
+
+    func remove() {
+        try? FileManager.default.removeItem(at: rootURL)
+    }
+}
+
+private func writeJSON(_ object: [String: Any], to url: URL) throws {
+    let data = try JSONSerialization.data(withJSONObject: object, options: [.sortedKeys])
+    try data.write(to: url, options: .atomic)
+}

--- a/Sources/ChineseCalendarUI/App/Store/ChineseCalendarStoreCoordinator.swift
+++ b/Sources/ChineseCalendarUI/App/Store/ChineseCalendarStoreCoordinator.swift
@@ -186,7 +186,7 @@ public final class ChineseCalendarStoreCoordinator {
                     state = .ready(
                         container: container,
                         contentLevel: .full,
-                        identityToken: result.manifest.datasetVersion
+                        identityToken: result.manifest.artifactVersion ?? result.manifest.datasetVersion
                     )
                     fullStoreDownloadTask = nil
                     clearCompletedDownloadProgressAfterDelay()

--- a/Sources/Package.swift
+++ b/Sources/Package.swift
@@ -86,6 +86,7 @@ let package = Package(
                 "ChineseCalendarLogging"
             ],
             path: "ChineseCalendarPersistence",
+            exclude: ["Tests"],
             swiftSettings: nonisolatedSwiftSettings
         ),
         .target(
@@ -118,6 +119,12 @@ let package = Package(
             name: "ChineseCalendarLoggingTests",
             dependencies: ["ChineseCalendarLogging"],
             path: "ChineseCalendarLogging/Tests",
+            swiftSettings: nonisolatedSwiftSettings
+        ),
+        .testTarget(
+            name: "ChineseCalendarPersistenceTests",
+            dependencies: ["ChineseCalendarPersistence"],
+            path: "ChineseCalendarPersistence/Tests",
             swiftSettings: nonisolatedSwiftSettings
         ),
         .testTarget(

--- a/project.yml
+++ b/project.yml
@@ -36,25 +36,28 @@ targets:
       - package: ChineseCalendarPackage
         product: ChineseCalendarPersistence
     preBuildScripts:
-      - name: Generate SwiftData Seed Store
+      - name: Validate SwiftData Seed Store
         script: |
           set -euo pipefail
-          "$SRCROOT/Scripts/BuildChineseCalendarSeedStore/generate_seed_store_if_needed.sh"
+          "$SRCROOT/Scripts/BuildChineseCalendarSeedStore/validate_seed_store.sh" "$SCRIPT_OUTPUT_FILE_0"
         inputFiles:
-          - "$(SRCROOT)/Scripts/BuildChineseCalendarSeedStore/generate_seed_store_if_needed.sh"
-          - "$(SRCROOT)/Scripts/BuildChineseCalendarSeedStore/Package.swift"
-          - "$(SRCROOT)/Scripts/BuildChineseCalendarSeedStore/Sources/ChineseCalendarSeedStoreBuilder/main.swift"
-          - "$(SRCROOT)/Data/Processed/swiftdata_import/manifest.json"
+          - "$(SRCROOT)/Scripts/BuildChineseCalendarSeedStore/validate_seed_store.sh"
+          - "$(SRCROOT)/Scripts/BuildChineseCalendarSeedStore/seed_store_identity.mjs"
+          - "$(SRCROOT)/Sources/ChineseCalendarPersistence/PersistenceSupport.swift"
           - "$(SRCROOT)/Data/Processed/swiftdata_import/chinese_lunar_years.jsonl"
           - "$(SRCROOT)/Data/Processed/swiftdata_import/chinese_lunar_months.jsonl"
           - "$(SRCROOT)/Data/Processed/swiftdata_import/chinese_date_expressions.jsonl"
           - "$(SRCROOT)/Data/Processed/swiftdata_import/dynasties.jsonl"
+          - "$(SRCROOT)/Data/Processed/swiftdata_import/emperors.jsonl"
+          - "$(SRCROOT)/Data/Processed/swiftdata_import/emperor_reign_segments.jsonl"
+          - "$(SRCROOT)/Data/Processed/swiftdata_import/reign_eras.jsonl"
           - "$(SRCROOT)/Data/Processed/swiftdata_import/orthodox_boundaries.jsonl"
           - "$(SRCROOT)/Data/Processed/swiftdata_import/orthodox_periods.jsonl"
           - "$(SRCROOT)/Data/Processed/swiftdata_import/orthodox_traditions.jsonl"
-        outputFiles:
           - "$(SRCROOT)/Apps/Shared/Resources/ChineseCalendarSeedStore.bundle/ChineseCalendar.sqlite"
           - "$(SRCROOT)/Apps/Shared/Resources/ChineseCalendarSeedStore.bundle/manifest.json"
+        outputFiles:
+          - "$(DERIVED_FILE_DIR)/ChineseCalendarSeedStore.validated"
     settings:
       base:
         PRODUCT_NAME: Chinese Calendar
@@ -103,25 +106,28 @@ targets:
       - package: ChineseCalendarPackage
         product: ChineseCalendarPersistence
     preBuildScripts:
-      - name: Generate SwiftData Seed Store
+      - name: Validate SwiftData Seed Store
         script: |
           set -euo pipefail
-          "$SRCROOT/Scripts/BuildChineseCalendarSeedStore/generate_seed_store_if_needed.sh"
+          "$SRCROOT/Scripts/BuildChineseCalendarSeedStore/validate_seed_store.sh" "$SCRIPT_OUTPUT_FILE_0"
         inputFiles:
-          - "$(SRCROOT)/Scripts/BuildChineseCalendarSeedStore/generate_seed_store_if_needed.sh"
-          - "$(SRCROOT)/Scripts/BuildChineseCalendarSeedStore/Package.swift"
-          - "$(SRCROOT)/Scripts/BuildChineseCalendarSeedStore/Sources/ChineseCalendarSeedStoreBuilder/main.swift"
-          - "$(SRCROOT)/Data/Processed/swiftdata_import/manifest.json"
+          - "$(SRCROOT)/Scripts/BuildChineseCalendarSeedStore/validate_seed_store.sh"
+          - "$(SRCROOT)/Scripts/BuildChineseCalendarSeedStore/seed_store_identity.mjs"
+          - "$(SRCROOT)/Sources/ChineseCalendarPersistence/PersistenceSupport.swift"
           - "$(SRCROOT)/Data/Processed/swiftdata_import/chinese_lunar_years.jsonl"
           - "$(SRCROOT)/Data/Processed/swiftdata_import/chinese_lunar_months.jsonl"
           - "$(SRCROOT)/Data/Processed/swiftdata_import/chinese_date_expressions.jsonl"
           - "$(SRCROOT)/Data/Processed/swiftdata_import/dynasties.jsonl"
+          - "$(SRCROOT)/Data/Processed/swiftdata_import/emperors.jsonl"
+          - "$(SRCROOT)/Data/Processed/swiftdata_import/emperor_reign_segments.jsonl"
+          - "$(SRCROOT)/Data/Processed/swiftdata_import/reign_eras.jsonl"
           - "$(SRCROOT)/Data/Processed/swiftdata_import/orthodox_boundaries.jsonl"
           - "$(SRCROOT)/Data/Processed/swiftdata_import/orthodox_periods.jsonl"
           - "$(SRCROOT)/Data/Processed/swiftdata_import/orthodox_traditions.jsonl"
-        outputFiles:
           - "$(SRCROOT)/Apps/Shared/Resources/ChineseCalendarSeedStore.bundle/ChineseCalendar.sqlite"
           - "$(SRCROOT)/Apps/Shared/Resources/ChineseCalendarSeedStore.bundle/manifest.json"
+        outputFiles:
+          - "$(DERIVED_FILE_DIR)/ChineseCalendarSeedStore.validated"
     settings:
       base:
         PRODUCT_NAME: Chinese Calendar


### PR DESCRIPTION
## 变更内容

- 以 `datasetVersion` 和 `artifactVersion` 为 seed store 定义稳定、内容寻址的身份，排除 `generatedAt` 等 provenance 字段。
- 将普通 Xcode build 改为只校验 committed seed store；stale 时提示执行 `make seed-store`，不再改写仓库中的数据库。
- 运行时按 `artifactVersion` 决定是否重新安装，并继续保护已安装的 full store。
- 补全实际输入声明、回归测试及数据库更新流程文档。
- 保留原有 bundled `ChineseCalendar.sqlite`，本 PR 只更新 manifest identity，不提交数据库二进制差异。

## 验证

- `Scripts/BuildChineseCalendarSeedStore/validate_seed_store.sh`
- Node identity tests：3/3
- Swift Package tests：95/95
- Xcode Simulator tests：79 passed，0 failed
- 最终基线上连续两次 Xcode Simulator build 成功；第二次未重新执行 validation phase
- SwiftFormat：0 files require formatting
- SwiftLint：0 violations
- SQLite `PRAGMA integrity_check`：`ok`；journal mode：`delete`
- 两次 build 前后 bundled SQLite/manifest 的 SHA-256、大小和 mtime 均未改变

Closes #110